### PR TITLE
Fix init script, wasn't working with two VPNs.

### DIFF
--- a/doc/examples/openwrt/fastd.init
+++ b/doc/examples/openwrt/fastd.init
@@ -233,7 +233,7 @@ generate_peer_group_config() {
 	config_get group_parent "$group" parent
 	[ "$parent" = "$group_parent" ] || return 0
 
-	if [ "$net" != "$peer_net" ]; then
+	if [ "$net" != "$group_net" ]; then
 		[ -z "$parent" ] || error "warning: the parent of peer group '$group' doesn't match its net, the peer group will be ignored"
 		return 0
 	fi


### PR DESCRIPTION
If two VPNs were configured via uci, the init script complained about
the peer group of its peers not matching its net.