### PR TITLE
config: accept port 0

### DIFF
--- a/src/config.y
+++ b/src/config.y
@@ -666,7 +666,7 @@ colon_or_port:	':'
 	;
 
 port:		colon_or_port TOK_UINT {
-			if ($2 < 1 || $2 > 65535) {
+			if ($2 < 0 || $2 > 65535) {
 				fastd_config_error(&@$, state, "invalid port");
 				YYERROR;
 			}


### PR DESCRIPTION
from the docs:
```
When an address without port or with port 0 is configured, a new socket with a random port will be created for each outgoing connection.
```

however:
with `bind any:0 default;`, fastd fails with `Error: config error: invalid port`.
`bind any port 0 default;` has the expected result - EDIT: goof on my side.

`bind any default;` should, as far as i understand the docs, also cause fastd to bind to a port, but there's neither an error message nor a listening port (checking with ss) - untouched in this PR.

i'm completely new to fastd, cool stuff.