### PR TITLE
cipher: fix OpenSSL linking for aes128-ctr

### DIFF
--- a/src/crypto/cipher/aes128_ctr/openssl/CMakeLists.txt
+++ b/src/crypto/cipher/aes128_ctr/openssl/CMakeLists.txt
@@ -3,4 +3,5 @@ if(ENABLE_OPENSSL)
     aes128_ctr_openssl.c
   )
   fastd_cipher_impl_include_directories(aes128-ctr openssl ${OPENSSL_INCLUDE_DIR})
+  fastd_cipher_impl_link_libraries(aes128-ctr openssl ${OPENSSL_CRYPTO_LIBRARY})
 endif(ENABLE_OPENSSL)


### PR DESCRIPTION
Signed-off-by: Felix Kaechele <felix@kaechele.ca>