### PR TITLE
avoid passing by value for const attribs

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -22,7 +22,7 @@
    The buffer is always allocated aligned to 16 bytes to allow efficient access for SIMD instructions
    etc. in crypto implementations
 */
-fastd_buffer_t fastd_buffer_alloc(size_t len, size_t head_space, size_t tail_space) {
+fastd_buffer_t fastd_buffer_alloc(const size_t len, const size_t head_space, const size_t tail_space) {
 	size_t base_len = alignto(head_space + len + tail_space, sizeof(fastd_block128_t));
 	if (base_len > ctx.max_buffer)
 		exit_fatal("BUG: oversized buffer alloc", base_len, ctx.max_buffer);

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -27,30 +27,32 @@ struct fastd_buffer {
 };
 
 
-fastd_buffer_t fastd_buffer_alloc(size_t len, size_t head_space, size_t tail_space);
+fastd_buffer_t fastd_buffer_alloc(const size_t len, const size_t head_space, const size_t tail_space);
 
 
 /** Duplicates a buffer */
-static inline fastd_buffer_t fastd_buffer_dup(fastd_buffer_t buffer, size_t head_space, size_t tail_space) {
-	fastd_buffer_t new_buffer = fastd_buffer_alloc(buffer.len, head_space, tail_space);
-	memcpy(new_buffer.data, buffer.data, buffer.len);
+static inline fastd_buffer_t fastd_buffer_dup(const fastd_buffer_t* const buffer, const size_t head_space, const size_t tail_space) {
+	fastd_buffer_t new_buffer = fastd_buffer_alloc(buffer->len, head_space, tail_space);
+	memcpy(new_buffer.data, buffer->data, buffer->len);
 	return new_buffer;
 }
 
 /** Frees a buffer */
-static inline void fastd_buffer_free(fastd_buffer_t buffer) {
-	free(buffer.base);
+static inline void fastd_buffer_free(fastd_buffer_t* const buffer) {
+	free(buffer->base);
+	buffer->base=NULL;
+	buffer->base_len=0;
 }
 
 /** Zeroes the trailing padding of a buffer, aligned to a multiple of 16 bytes */
-static inline void fastd_buffer_zero_pad(fastd_buffer_t buffer) {
-	void *end = buffer.data + buffer.len;
-	void *end_align = buffer.base + alignto(end - buffer.base, sizeof(fastd_block128_t));
+static inline void fastd_buffer_zero_pad(fastd_buffer_t* const buffer) {
+	void *end = buffer->data + buffer->len;
+	void *end_align = buffer->base + alignto(end - buffer->base, sizeof(fastd_block128_t));
 	memset(end, 0, end_align - end);
 }
 
 /** Pushes the data head (decreases the head space) */
-static inline void fastd_buffer_push(fastd_buffer_t *buffer, size_t len) {
+static inline void fastd_buffer_push(fastd_buffer_t *const buffer, const size_t len) {
 	if (len > (size_t)(buffer->data - buffer->base))
 		exit_bug("tried to push buffer across base");
 
@@ -59,20 +61,20 @@ static inline void fastd_buffer_push(fastd_buffer_t *buffer, size_t len) {
 }
 
 /** Pushes the data head and fills with zeroes */
-static inline void fastd_buffer_push_zero(fastd_buffer_t *buffer, size_t len) {
+static inline void fastd_buffer_push_zero(fastd_buffer_t *const buffer, const size_t len) {
 	fastd_buffer_push(buffer, len);
 	memset(buffer->data, 0, len);
 }
 
 /** Pushes the data head and copies data into the new space */
-static inline void fastd_buffer_push_from(fastd_buffer_t *buffer, const void *data, size_t len) {
+static inline void fastd_buffer_push_from(fastd_buffer_t * const buffer, const void * const data, const size_t len) {
 	fastd_buffer_push(buffer, len);
 	memcpy(buffer->data, data, len);
 }
 
 
 /** Pulls the buffer head (increases the head space) */
-static inline void fastd_buffer_pull(fastd_buffer_t *buffer, size_t len) {
+static inline void fastd_buffer_pull(fastd_buffer_t * const buffer, const size_t len) {
 	if (buffer->len < len)
 		exit_bug("tried to pull buffer across tail");
 
@@ -81,7 +83,7 @@ static inline void fastd_buffer_pull(fastd_buffer_t *buffer, size_t len) {
 }
 
 /** Pulls the buffer head, copying the removed buffer data somewhere else */
-static inline void fastd_buffer_pull_to(fastd_buffer_t *buffer, void *data, size_t len) {
+static inline void fastd_buffer_pull_to(fastd_buffer_t * const buffer, void * const data, const size_t len) {
 	memcpy(data, buffer->data, len);
 	fastd_buffer_pull(buffer, len);
 }

--- a/src/handshake.c
+++ b/src/handshake.c
@@ -483,5 +483,5 @@ void fastd_handshake_handle(
 
 end_free:
 	free(peer_version);
-	fastd_buffer_free(buffer);
+	fastd_buffer_free(&buffer);
 }

--- a/src/methods/composed_gmac/composed_gmac.c
+++ b/src/methods/composed_gmac/composed_gmac.c
@@ -212,7 +212,7 @@ static bool method_encrypt(
 		    session->cipher_state, outblocks + 1, inblocks, n_blocks * sizeof(fastd_block128_t), nonce))
 		goto fail;
 
-	fastd_buffer_zero_pad(*out);
+	fastd_buffer_zero_pad(out);
 	put_size(&outblocks[n_blocks + 1], in.len);
 
 	if (!session->ghash->digest(
@@ -221,7 +221,7 @@ static bool method_encrypt(
 
 	block_xor_a(&outblocks[0], &tag);
 
-	fastd_buffer_free(in);
+	fastd_buffer_free(&in);
 
 	fastd_method_put_common_header(out, session->common.send_nonce, 0);
 	fastd_method_increment_nonce(&session->common);
@@ -229,7 +229,7 @@ static bool method_encrypt(
 	return true;
 
 fail:
-	fastd_buffer_free(*out);
+	fastd_buffer_free(out);
 	return false;
 }
 
@@ -291,12 +291,12 @@ static bool method_decrypt(
 	else
 		out->len = 0;
 
-	fastd_buffer_free(in);
+	fastd_buffer_free(&in);
 
 	return true;
 
 fail:
-	fastd_buffer_free(*out);
+	fastd_buffer_free(out);
 	return false;
 }
 

--- a/src/methods/composed_umac/composed_umac.c
+++ b/src/methods/composed_umac/composed_umac.c
@@ -182,14 +182,14 @@ static bool method_encrypt(
 		    session->cipher_state, outblocks + 1, inblocks, n_blocks * sizeof(fastd_block128_t), nonce))
 		goto fail;
 
-	fastd_buffer_zero_pad(*out);
+	fastd_buffer_zero_pad(out);
 
 	if (!session->uhash->digest(session->uhash_state, &tag, outblocks + 1, out->len - sizeof(fastd_block128_t)))
 		goto fail;
 
 	block_xor_a(&outblocks[0], &tag);
 
-	fastd_buffer_free(in);
+	fastd_buffer_free(&in);
 
 	fastd_method_put_common_header(out, session->common.send_nonce, 0);
 	fastd_method_increment_nonce(&session->common);
@@ -197,7 +197,7 @@ static bool method_encrypt(
 	return true;
 
 fail:
-	fastd_buffer_free(*out);
+	fastd_buffer_free(out);
 	return false;
 }
 
@@ -257,12 +257,12 @@ static bool method_decrypt(
 	else
 		out->len = 0;
 
-	fastd_buffer_free(in);
+	fastd_buffer_free(&in);
 
 	return true;
 
 fail:
-	fastd_buffer_free(*out);
+	fastd_buffer_free(out);
 	return false;
 }
 

--- a/src/methods/generic_gmac/generic_gmac.c
+++ b/src/methods/generic_gmac/generic_gmac.c
@@ -177,7 +177,7 @@ static bool method_encrypt(
 		    session->cipher_state, outblocks, inblocks, n_blocks * sizeof(fastd_block128_t), nonce))
 		goto fail;
 
-	fastd_buffer_zero_pad(*out);
+	fastd_buffer_zero_pad(out);
 
 	put_size(&outblocks[n_blocks], in.len - sizeof(fastd_block128_t));
 
@@ -186,7 +186,7 @@ static bool method_encrypt(
 
 	block_xor_a(&outblocks[0], &tag);
 
-	fastd_buffer_free(in);
+	fastd_buffer_free(&in);
 
 	fastd_method_put_common_header(out, session->common.send_nonce, 0);
 	fastd_method_increment_nonce(&session->common);
@@ -194,7 +194,7 @@ static bool method_encrypt(
 	return true;
 
 fail:
-	fastd_buffer_free(*out);
+	fastd_buffer_free(out);
 	return false;
 }
 
@@ -240,7 +240,7 @@ static bool method_decrypt(
 	if (!block_equal(&tag, &outblocks[0]))
 		goto fail;
 
-	fastd_buffer_free(in);
+	fastd_buffer_free(&in);
 
 	fastd_buffer_pull(out, sizeof(fastd_block128_t));
 
@@ -253,7 +253,7 @@ static bool method_decrypt(
 	return true;
 
 fail:
-	fastd_buffer_free(*out);
+	fastd_buffer_free(out);
 	return false;
 }
 

--- a/src/methods/generic_poly1305/generic_poly1305.c
+++ b/src/methods/generic_poly1305/generic_poly1305.c
@@ -154,7 +154,7 @@ static bool method_encrypt(
 
 	fastd_buffer_push_from(out, tag, TAGBYTES);
 
-	fastd_buffer_free(in);
+	fastd_buffer_free(&in);
 
 	fastd_method_put_common_header(out, session->common.send_nonce, 0);
 	fastd_method_increment_nonce(&session->common);
@@ -162,7 +162,7 @@ static bool method_encrypt(
 	return true;
 
 fail:
-	fastd_buffer_free(*out);
+	fastd_buffer_free(out);
 	return false;
 }
 
@@ -209,7 +209,7 @@ static bool method_decrypt(
 	if (crypto_onetimeauth_poly1305_verify(tag, in.data, in.len, out->data) != 0)
 		goto fail;
 
-	fastd_buffer_free(in);
+	fastd_buffer_free(&in);
 
 	fastd_buffer_pull(out, KEYBYTES);
 
@@ -222,7 +222,7 @@ static bool method_decrypt(
 	return true;
 
 fail:
-	fastd_buffer_free(*out);
+	fastd_buffer_free(out);
 
 	/* restore input buffer */
 	fastd_buffer_push_from(&in, tag, TAGBYTES);

--- a/src/methods/generic_umac/generic_umac.c
+++ b/src/methods/generic_umac/generic_umac.c
@@ -146,14 +146,14 @@ static bool method_encrypt(
 		    session->cipher_state, outblocks, inblocks, n_blocks * sizeof(fastd_block128_t), nonce))
 		goto fail;
 
-	fastd_buffer_zero_pad(*out);
+	fastd_buffer_zero_pad(out);
 
 	if (!session->uhash->digest(session->uhash_state, &tag, outblocks + 1, out->len - sizeof(fastd_block128_t)))
 		goto fail;
 
 	block_xor_a(&outblocks[0], &tag);
 
-	fastd_buffer_free(in);
+	fastd_buffer_free(&in);
 
 	fastd_method_put_common_header(out, session->common.send_nonce, 0);
 	fastd_method_increment_nonce(&session->common);
@@ -161,7 +161,7 @@ static bool method_encrypt(
 	return true;
 
 fail:
-	fastd_buffer_free(*out);
+	fastd_buffer_free(out);
 	return false;
 }
 
@@ -205,7 +205,7 @@ static bool method_decrypt(
 	if (!block_equal(&tag, &outblocks[0]))
 		goto fail;
 
-	fastd_buffer_free(in);
+	fastd_buffer_free(&in);
 
 	fastd_buffer_pull(out, sizeof(fastd_block128_t));
 
@@ -218,7 +218,7 @@ static bool method_decrypt(
 	return true;
 
 fail:
-	fastd_buffer_free(*out);
+	fastd_buffer_free(out);
 	return false;
 }
 

--- a/src/protocols/ec25519_fhmqvc/ec25519_fhmqvc.c
+++ b/src/protocols/ec25519_fhmqvc/ec25519_fhmqvc.c
@@ -113,7 +113,7 @@ static void protocol_handle_recv(fastd_peer_t *peer, fastd_buffer_t buffer) {
 	fastd_buffer_t recv_buffer;
 	bool ok = false, reordered = false;
 
-	fastd_buffer_zero_pad(buffer);
+	fastd_buffer_zero_pad(&buffer);
 
 	if (is_session_valid(&peer->protocol_state->old_session))
 		ok = peer->protocol_state->old_session.method->provider->decrypt(
@@ -152,23 +152,23 @@ static void protocol_handle_recv(fastd_peer_t *peer, fastd_buffer_t buffer) {
 	if (recv_buffer.len)
 		fastd_handle_receive(peer, recv_buffer, reordered);
 	else
-		fastd_buffer_free(recv_buffer);
+		fastd_buffer_free(&recv_buffer);
 
 	return;
 
 fail:
-	fastd_buffer_free(buffer);
+	fastd_buffer_free(&buffer);
 }
 
 /** Encrypts and sends a packet to a peer using a specified session */
 static void session_send(fastd_peer_t *peer, fastd_buffer_t buffer, protocol_session_t *session) {
 	size_t stat_size = buffer.len;
 
-	fastd_buffer_zero_pad(buffer);
+	fastd_buffer_zero_pad(&buffer);
 
 	fastd_buffer_t send_buffer;
 	if (!session->method->provider->encrypt(peer, session->method_state, &send_buffer, buffer)) {
-		fastd_buffer_free(buffer);
+		fastd_buffer_free(&buffer);
 		pr_error("failed to encrypt packet for %P", peer);
 		return;
 	}
@@ -180,7 +180,7 @@ static void session_send(fastd_peer_t *peer, fastd_buffer_t buffer, protocol_ses
 /** Encrypts and sends a packet to a peer */
 static void protocol_send(fastd_peer_t *peer, fastd_buffer_t buffer) {
 	if (!peer->protocol_state || !fastd_peer_is_established(peer) || !check_session(peer)) {
-		fastd_buffer_free(buffer);
+		fastd_buffer_free(&buffer);
 		return;
 	}
 

--- a/src/receive.c
+++ b/src/receive.c
@@ -146,7 +146,7 @@ static inline void handle_socket_receive_known(
 	fastd_socket_t *sock, const fastd_peer_address_t *local_addr, const fastd_peer_address_t *remote_addr,
 	fastd_peer_t *peer, fastd_buffer_t buffer) {
 	if (!fastd_peer_may_connect(peer)) {
-		fastd_buffer_free(buffer);
+		fastd_buffer_free(&buffer);
 		return;
 	}
 
@@ -155,7 +155,7 @@ static inline void handle_socket_receive_known(
 	switch (*packet_type) {
 	case PACKET_DATA:
 		if (!fastd_peer_is_established(peer) || !fastd_peer_address_equal(&peer->local_address, local_addr)) {
-			fastd_buffer_free(buffer);
+			fastd_buffer_free(&buffer);
 
 			if (!backoff_unknown(remote_addr)) {
 				pr_debug("unexpectedly received payload data from %P[%I]", peer, remote_addr);
@@ -185,7 +185,7 @@ static inline void handle_socket_receive_unknown(
 
 	switch (*packet_type) {
 	case PACKET_DATA:
-		fastd_buffer_free(buffer);
+		fastd_buffer_free(&buffer);
 
 		if (!backoff_unknown(remote_addr)) {
 			pr_debug("unexpectedly received payload data from unknown address %I", remote_addr);
@@ -206,7 +206,7 @@ static inline void handle_socket_receive(
 
 	if (sock->peer) {
 		if (!fastd_peer_address_equal(&sock->peer->address, remote_addr)) {
-			fastd_buffer_free(buffer);
+			fastd_buffer_free(&buffer);
 			return;
 		}
 
@@ -221,7 +221,7 @@ static inline void handle_socket_receive(
 		handle_socket_receive_unknown(sock, local_addr, remote_addr, buffer);
 	} else {
 		pr_debug("received packet from unknown peer %I", remote_addr);
-		fastd_buffer_free(buffer);
+		fastd_buffer_free(&buffer);
 	}
 }
 
@@ -248,7 +248,7 @@ void fastd_receive(fastd_socket_t *sock) {
 		if (len < 0)
 			pr_warn_errno("recvmsg");
 
-		fastd_buffer_free(buffer);
+		fastd_buffer_free(&buffer);
 		return;
 	}
 
@@ -259,7 +259,7 @@ void fastd_receive(fastd_socket_t *sock) {
 #ifdef USE_PKTINFO
 	if (!local_addr.sa.sa_family) {
 		pr_error("received packet without packet info");
-		fastd_buffer_free(buffer);
+		fastd_buffer_free(&buffer);
 		return;
 	}
 #endif
@@ -275,7 +275,7 @@ void fastd_handle_receive(fastd_peer_t *peer, fastd_buffer_t buffer, bool reorde
 	if (conf.mode == MODE_TAP) {
 		if (buffer.len < sizeof(fastd_eth_header_t)) {
 			pr_debug("received truncated packet");
-			fastd_buffer_free(buffer);
+			fastd_buffer_free(&buffer);
 			return;
 		}
 
@@ -297,5 +297,5 @@ void fastd_handle_receive(fastd_peer_t *peer, fastd_buffer_t buffer, bool reorde
 		return;
 	}
 
-	fastd_buffer_free(buffer);
+	fastd_buffer_free(&buffer);
 }

--- a/src/send.c
+++ b/src/send.c
@@ -154,7 +154,7 @@ void fastd_send(
 		fastd_stats_add(peer, STAT_TX, stat_size);
 	}
 
-	fastd_buffer_free(buffer);
+	fastd_buffer_free(&buffer);
 }
 
 /** Encrypts and sends a payload packet to all peers */
@@ -171,10 +171,10 @@ static inline void send_all(fastd_buffer_t buffer, fastd_peer_t *source) {
 			return;
 		}
 
-		conf.protocol->send(dest, fastd_buffer_dup(buffer, conf.encrypt_headroom, 0));
+		conf.protocol->send(dest, fastd_buffer_dup(&buffer, conf.encrypt_headroom, 0));
 	}
 
-	fastd_buffer_free(buffer);
+	fastd_buffer_free(&buffer);
 }
 
 /** Handles sending of a payload packet to a single peer in TAP mode */
@@ -184,7 +184,7 @@ static inline bool send_data_tap_single(fastd_buffer_t buffer, fastd_peer_t *sou
 
 	if (buffer.len < sizeof(fastd_eth_header_t)) {
 		pr_debug("truncated ethernet packet");
-		fastd_buffer_free(buffer);
+		fastd_buffer_free(&buffer);
 		return true;
 	}
 
@@ -206,7 +206,7 @@ static inline bool send_data_tap_single(fastd_buffer_t buffer, fastd_peer_t *sou
 		return false;
 
 	if (!dest || dest == source) {
-		fastd_buffer_free(buffer);
+		fastd_buffer_free(&buffer);
 		return true;
 	}
 


### PR DESCRIPTION
Please kindly treat this as a presubmission enquiry. I would continue local development if you consider this useful. But of course, I'd feel just as honoured if you decide to just snap this from me :o)

I went through a few functions in buffer.[ch] and looked at what arguments remain invariant during the execution of these functions and if I had felt that this was not just some accident then I added a "const" to the declaration/definition. And when you pass a struct by value that is not changed, then I suggest to pass a pointer to that struct, instead.

I hope I have not messed anything up - I failed to invoke the test routines on this end, meson was too much fo me, but it compiles. If I did not destroy the semantics by accident [and if, maybe this is still fixable], since these buffer routines are executed with every package if I get this right, this should be rather beneficial to the performance.