### PR TITLE
doc: openwrt: fix indentation

### DIFF
--- a/doc/examples/openwrt/fastd.init
+++ b/doc/examples/openwrt/fastd.init
@@ -327,8 +327,8 @@ reload_instance() {
 
 	update_peer_groups "$s" true
 
-        rc_procd start_service "$s"
-        procd_send_signal fastd "$s"
+	rc_procd start_service "$s"
+	procd_send_signal fastd "$s"
 }
 
 start_service() {


### PR DESCRIPTION
reload_instances was using combined tabs and spaces.

Remove the space indentation to match the rest of the file.