### PR TITLE
Introducing 'const' where args are meant to remain invariant

### DIFF
--- a/src/async.c
+++ b/src/async.c
@@ -44,7 +44,7 @@ void fastd_async_init(void) {
 }
 
 /** Handles a DNS resolver response */
-static void handle_resolve_return(const fastd_async_resolve_return_t *resolve_return) {
+static void handle_resolve_return(const fastd_async_resolve_return_t * const resolve_return) {
 	fastd_peer_t *peer = fastd_peer_find_by_id(resolve_return->peer_id);
 	if (!peer || !fastd_peer_is_enabled(peer))
 		return;
@@ -59,7 +59,7 @@ static void handle_resolve_return(const fastd_async_resolve_return_t *resolve_re
 #ifdef WITH_DYNAMIC_PEERS
 
 /** Handles a on-verify response */
-static void handle_verify_return(const fastd_async_verify_return_t *verify_return) {
+static void handle_verify_return(const fastd_async_verify_return_t * const verify_return) {
 	fastd_peer_t *peer = fastd_peer_find_by_id(verify_return->peer_id);
 	if (!peer)
 		return;
@@ -119,7 +119,7 @@ void fastd_async_handle(void) {
 }
 
 /** Enqueues a new async notification */
-void fastd_async_enqueue(fastd_async_type_t type, const void *data, size_t len) {
+void fastd_async_enqueue(const fastd_async_type_t type, const void * const data, const size_t len) {
 	fastd_async_hdr_t header;
 	/* use memset to zero the holes in the struct to make valgrind happy */
 	memset(&header, 0, sizeof(header));

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -50,8 +50,8 @@ void fastd_cleanup_buffers(void) {
    The buffer is always allocated aligned to 16 bytes to allow efficient access for SIMD instructions
    etc. in crypto implementations
 */
-fastd_buffer_t *fastd_buffer_alloc(size_t len, size_t headroom) {
-	size_t base_len = alignto(headroom + len, sizeof(fastd_block128_t));
+fastd_buffer_t *fastd_buffer_alloc(const size_t len, const size_t headroom) {
+	const size_t base_len = alignto(headroom + len, sizeof(fastd_block128_t));
 	if (base_len > ctx.max_buffer)
 		exit_fatal("BUG: oversized buffer alloc (%Z > %Z)", base_len, ctx.max_buffer);
 
@@ -71,7 +71,7 @@ fastd_buffer_t *fastd_buffer_alloc(size_t len, size_t headroom) {
 }
 
 /** Returns a buffer to the buffer pool */
-void fastd_buffer_free(fastd_buffer_t *buffer) {
+void fastd_buffer_free(fastd_buffer_t * const buffer) {
 	buffer->len = SIZE_MAX;
 	buffer->data = buffers;
 	buffers = buffer;

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -36,8 +36,8 @@ void fastd_init_buffers(void);
 void fastd_cleanup_buffers(void);
 
 
-fastd_buffer_t *fastd_buffer_alloc(size_t len, size_t headroom);
-void fastd_buffer_free(fastd_buffer_t *buffer);
+fastd_buffer_t *fastd_buffer_alloc(const size_t len, const size_t headroom);
+void fastd_buffer_free(fastd_buffer_t * const buffer);
 
 
 /** Duplicates a buffer */
@@ -51,7 +51,7 @@ static inline fastd_buffer_t *fastd_buffer_dup(const fastd_buffer_t *buffer, siz
    Returns the amount of headroom a buffer has
    (the number of bytes that can be pushed)
 */
-static inline size_t fastd_buffer_headroom(const fastd_buffer_t *buffer) {
+static inline size_t fastd_buffer_headroom(const fastd_buffer_t * const buffer) {
 	return (const uint8_t *)buffer->data - buffer->base;
 }
 
@@ -61,7 +61,7 @@ static inline size_t fastd_buffer_headroom(const fastd_buffer_t *buffer) {
 
    Consumes the passed buffer.
 */
-static inline fastd_buffer_t *fastd_buffer_align(fastd_buffer_t *buffer, size_t min_headroom) {
+static inline fastd_buffer_t *fastd_buffer_align(fastd_buffer_t * const buffer, const size_t min_headroom) {
 	ssize_t surplus = fastd_buffer_headroom(buffer) - min_headroom;
 	if (surplus >= 0 && surplus % sizeof(fastd_block128_t) == 0)
 		return buffer;
@@ -73,14 +73,14 @@ static inline fastd_buffer_t *fastd_buffer_align(fastd_buffer_t *buffer, size_t 
 }
 
 /** Zeroes the trailing padding of a buffer, aligned to a multiple of 16 bytes */
-static inline void fastd_buffer_zero_pad(fastd_buffer_t *buffer) {
+static inline void fastd_buffer_zero_pad(fastd_buffer_t * const buffer) {
 	uint8_t *end = buffer->data + buffer->len;
 	uint8_t *end_align = buffer->base + alignto(end - buffer->base, sizeof(fastd_block128_t));
 	memset(end, 0, end_align - end);
 }
 
 /** Pushes the data head (decreases the head space) */
-static inline void fastd_buffer_push(fastd_buffer_t *buffer, size_t len) {
+static inline void fastd_buffer_push(fastd_buffer_t * const buffer, const size_t len) {
 	if (len > fastd_buffer_headroom(buffer))
 		exit_bug("tried to push buffer across base");
 
@@ -89,20 +89,20 @@ static inline void fastd_buffer_push(fastd_buffer_t *buffer, size_t len) {
 }
 
 /** Pushes the data head and fills with zeroes */
-static inline void fastd_buffer_push_zero(fastd_buffer_t *buffer, size_t len) {
+static inline void fastd_buffer_push_zero(fastd_buffer_t * const buffer, const size_t len) {
 	fastd_buffer_push(buffer, len);
 	memset(buffer->data, 0, len);
 }
 
 /** Pushes the data head and copies data into the new space */
-static inline void fastd_buffer_push_from(fastd_buffer_t *buffer, const void *data, size_t len) {
+static inline void fastd_buffer_push_from(fastd_buffer_t * const buffer, const void * const data, const size_t len) {
 	fastd_buffer_push(buffer, len);
 	memcpy(buffer->data, data, len);
 }
 
 
 /** Pulls the buffer head (increases the head space) */
-static inline void fastd_buffer_pull(fastd_buffer_t *buffer, size_t len) {
+static inline void fastd_buffer_pull(fastd_buffer_t * const buffer, const size_t len) {
 	if (buffer->len < len)
 		exit_bug("tried to pull buffer across tail");
 
@@ -111,18 +111,18 @@ static inline void fastd_buffer_pull(fastd_buffer_t *buffer, size_t len) {
 }
 
 /** Pulls the buffer head, copying the removed buffer data somewhere else */
-static inline void fastd_buffer_pull_to(fastd_buffer_t *buffer, void *data, size_t len) {
+static inline void fastd_buffer_pull_to(fastd_buffer_t * const buffer, void * const data, const size_t len) {
 	memcpy(data, buffer->data, len);
 	fastd_buffer_pull(buffer, len);
 }
 
 /** Creates a read-only view of a buffer */
-static inline fastd_buffer_view_t fastd_buffer_get_view(const fastd_buffer_t *buffer) {
+static inline fastd_buffer_view_t fastd_buffer_get_view(const fastd_buffer_t * const buffer) {
 	return (fastd_buffer_view_t){ .data = buffer->data, .len = buffer->len };
 }
 
 /** Pulls the view head (increases the head space) */
-static inline void fastd_buffer_view_pull(fastd_buffer_view_t *view, size_t len) {
+static inline void fastd_buffer_view_pull(fastd_buffer_view_t * const view, const size_t len) {
 	if (view->len < len)
 		exit_bug("tried to pull view across tail");
 
@@ -131,7 +131,7 @@ static inline void fastd_buffer_view_pull(fastd_buffer_view_t *view, size_t len)
 }
 
 /** Pulls the view head, copying the removed view data somewhere else */
-static inline void fastd_buffer_view_pull_to(fastd_buffer_view_t *view, void *data, size_t len) {
+static inline void fastd_buffer_view_pull_to(fastd_buffer_view_t * const view, void * const data, const size_t len) {
 	memcpy(data, view->data, len);
 	fastd_buffer_view_pull(view, len);
 }

--- a/src/config.c
+++ b/src/config.c
@@ -62,13 +62,13 @@ static void default_config(void) {
 }
 
 /** Handles the configuration of a handshake protocol */
-void fastd_config_protocol(const char *name) {
+void fastd_config_protocol(const char * const name) {
 	if (strcmp(name, conf.protocol->name))
 		exit_error("config error: protocol `%s' not supported", name);
 }
 
 /** Handles the configuration of a crypto method */
-void fastd_config_method(fastd_peer_group_t *group, const char *name) {
+void fastd_config_method(fastd_peer_group_t *group, const char * const name) {
 	fastd_string_stack_t **method;
 
 	for (method = &group->methods; *method; method = &(*method)->next) {
@@ -82,7 +82,7 @@ void fastd_config_method(fastd_peer_group_t *group, const char *name) {
 }
 
 /** Configures an interface name or name pattern */
-bool fastd_config_ifname(fastd_peer_t *peer, const char *ifname) {
+bool fastd_config_ifname(fastd_peer_t *peer, const char * const ifname) {
 	if (strchr(ifname, '/'))
 		return false;
 
@@ -104,7 +104,7 @@ bool fastd_config_ifname(fastd_peer_t *peer, const char *ifname) {
 }
 
 /** Handles the configuration of a cipher implementation */
-void fastd_config_cipher(const char *name, const char *impl) {
+void fastd_config_cipher(const char * const name, const char * const impl) {
 	if (!fastd_cipher_config(name, impl))
 		exit_error(
 			"config error: implementation `%s' is not supported for cipher `%s' (or cipher `%s' is not supported)",
@@ -112,7 +112,7 @@ void fastd_config_cipher(const char *name, const char *impl) {
 }
 
 /** Handles the configuration of a MAC implementation */
-void fastd_config_mac(const char *name, const char *impl) {
+void fastd_config_mac(const char * const name, const char * const impl) {
 	if (!fastd_mac_config(name, impl))
 		exit_error(
 			"config error: implementation `%s' is not supported for MAC `%s' (or MAC `%s' is not supported)",
@@ -120,7 +120,7 @@ void fastd_config_mac(const char *name, const char *impl) {
 }
 
 /** Handles the configuration of a bind address */
-void fastd_config_bind_address(const fastd_peer_address_t *address, const char *bindtodev, unsigned flags) {
+void fastd_config_bind_address(const fastd_peer_address_t * const address, const char * const bindtodev, const unsigned flags) {
 #ifndef USE_BINDTODEVICE
 	if (bindtodev && !fastd_peer_address_is_v6_ll(address))
 		exit_error("config error: device bind configuration not supported on this system");

--- a/src/config.h
+++ b/src/config.h
@@ -26,12 +26,12 @@ struct fastd_parser_state {
 };
 
 
-void fastd_config_protocol(const char *name);
-void fastd_config_method(fastd_peer_group_t *group, const char *name);
-bool fastd_config_ifname(fastd_peer_t *peer, const char *ifname);
-void fastd_config_cipher(const char *name, const char *impl);
-void fastd_config_mac(const char *name, const char *impl);
-void fastd_config_bind_address(const fastd_peer_address_t *address, const char *bindtodev, unsigned flags);
+void fastd_config_protocol(const char * const name);
+void fastd_config_method(fastd_peer_group_t *group, const char * const name);
+bool fastd_config_ifname(fastd_peer_t *peer, const char * const ifname);
+void fastd_config_cipher(const char *name, const char * const impl);
+void fastd_config_mac(const char * const name, const char * const impl);
+void fastd_config_bind_address(const fastd_peer_address_t * const address, const char * const bindtodev, const unsigned flags);
 void fastd_config_release(void);
 void fastd_config_handle_options(int argc, char *const argv[]);
 void fastd_config_verify(void);

--- a/src/fastd.c
+++ b/src/fastd.c
@@ -51,7 +51,7 @@ static volatile int sig_terminate = 0;   /**< Holds the signal number when a SIG
 
 
 /** Signal handler; just saves the signals to be handled later */
-static void on_signal(int signo) {
+static void on_signal(const int signo) {
 	switch (signo) {
 	case SIGHUP:
 		sig_reload = true;
@@ -180,7 +180,7 @@ static inline void on_pre_up(void) {
 }
 
 /** Calls the on-up command */
-static inline void on_up(fastd_iface_t *iface) {
+static inline void on_up(fastd_iface_t * const iface) {
 	fastd_shell_env_t *env = fastd_shell_env_alloc();
 	fastd_shell_env_set_iface(env, iface);
 	fastd_shell_command_exec_sync(&conf.peer_group->on_up, env, NULL);
@@ -188,7 +188,7 @@ static inline void on_up(fastd_iface_t *iface) {
 }
 
 /** Calls the on-down command */
-static inline void on_down(fastd_iface_t *iface) {
+static inline void on_down(fastd_iface_t * const iface) {
 	fastd_shell_env_t *env = fastd_shell_env_alloc();
 	fastd_shell_env_set_iface(env, iface);
 	fastd_shell_command_exec_sync(&conf.peer_group->on_down, env, NULL);
@@ -413,7 +413,7 @@ static inline void init_early(void) {
 
    This also handles special run modes like \em generate-key and \em verify-config.
 */
-static inline void init_config(int *status_fd) {
+static inline void init_config(int *const status_fd) {
 	if (conf.verify_config) {
 		fastd_config_verify();
 		exit(0);

--- a/src/fastd.h
+++ b/src/fastd.h
@@ -364,30 +364,30 @@ void fastd_main(int argc, char *argv[]);
 
 
 void fastd_send(
-	const fastd_socket_t *sock, const fastd_peer_address_t *local_addr, const fastd_peer_address_t *remote_addr,
-	fastd_peer_t *peer, fastd_buffer_t *buffer, size_t stat_size);
-void fastd_send_data(fastd_buffer_t *buffer, fastd_peer_t *source, fastd_peer_t *dest);
+	const fastd_socket_t * const sock, const fastd_peer_address_t * const local_addr, const fastd_peer_address_t * const remote_addr,
+	fastd_peer_t * const peer, fastd_buffer_t * const buffer, const size_t stat_size);
+void fastd_send_data(fastd_buffer_t * const buffer, fastd_peer_t * const source, fastd_peer_t * const dest);
 
 void fastd_receive_unknown_init(void);
 void fastd_receive_unknown_free(void);
 void fastd_receive(fastd_socket_t *sock);
-void fastd_handle_receive(fastd_peer_t *peer, fastd_buffer_t *buffer, bool reordered);
+void fastd_handle_receive(fastd_peer_t * const peer, fastd_buffer_t * const buffer, const bool reordered);
 
 void fastd_close_all_fds(void);
 
 void fastd_socket_bind_all(void);
-fastd_socket_t *fastd_socket_open(fastd_peer_t *peer, int af);
-void fastd_socket_close(fastd_socket_t *sock);
-void fastd_socket_error(fastd_socket_t *sock);
+fastd_socket_t *fastd_socket_open(fastd_peer_t * const peer, const int af);
+void fastd_socket_close(fastd_socket_t * const sock);
+void fastd_socket_error(fastd_socket_t * const sock);
 
-void fastd_resolve_peer(fastd_peer_t *peer, fastd_remote_t *remote);
+void fastd_resolve_peer(fastd_peer_t * const peer, fastd_remote_t * const remote);
 
-fastd_iface_t *fastd_iface_open(fastd_peer_t *peer);
-void fastd_iface_handle(fastd_iface_t *iface);
-void fastd_iface_write(fastd_iface_t *iface, fastd_buffer_t *buffer);
-void fastd_iface_close(fastd_iface_t *iface);
+fastd_iface_t *fastd_iface_open(fastd_peer_t * const peer);
+void fastd_iface_handle(const fastd_iface_t * const iface);
+void fastd_iface_write(const fastd_iface_t * const iface, fastd_buffer_t * const buffer);
+void fastd_iface_close(fastd_iface_t * const iface);
 
-void fastd_random_bytes(void *buffer, size_t len, bool secure);
+void fastd_random_bytes(void * const buffer, const size_t len, const bool secure);
 int64_t fastd_get_time(void);
 
 
@@ -429,13 +429,13 @@ static inline void fastd_status_handle(void) {}
 
 
 /** Returns a random number between \a min (inclusively) and \a max (exclusively) */
-static inline int fastd_rand(int min, int max) {
+static inline int fastd_rand(const int min, const int max) {
 	unsigned int r = (unsigned int)random();
 	return (r % (max - min) + min);
 }
 
 /** Sets the O_NONBLOCK flag on a file descriptor */
-static inline void fastd_setnonblock(int fd) {
+static inline void fastd_setnonblock(const int fd) {
 	int flags = fcntl(fd, F_GETFL);
 	if (flags < 0)
 		exit_errno("Getting file status flags failed: fcntl");
@@ -446,7 +446,7 @@ static inline void fastd_setnonblock(int fd) {
 
 
 /** Returns the maximum payload size \em fastd is configured to transport */
-static inline size_t fastd_max_payload(uint16_t mtu) {
+static inline size_t fastd_max_payload(const uint16_t mtu) {
 	switch (conf.mode) {
 	case MODE_TAP:
 	case MODE_MULTITAP:
@@ -460,14 +460,14 @@ static inline size_t fastd_max_payload(uint16_t mtu) {
 
 
 /** Returns the source address of an ethernet packet */
-static inline fastd_eth_addr_t fastd_buffer_source_address(const fastd_buffer_t *buffer) {
+static inline fastd_eth_addr_t fastd_buffer_source_address(const fastd_buffer_t * const buffer) {
 	fastd_eth_addr_t ret;
 	memcpy(&ret, buffer->data + offsetof(fastd_eth_header_t, source), sizeof(fastd_eth_addr_t));
 	return ret;
 }
 
 /** Returns the destination address of an ethernet packet */
-static inline fastd_eth_addr_t fastd_buffer_dest_address(const fastd_buffer_t *buffer) {
+static inline fastd_eth_addr_t fastd_buffer_dest_address(const fastd_buffer_t * const buffer) {
 	fastd_eth_addr_t ret;
 	memcpy(&ret, buffer->data + offsetof(fastd_eth_header_t, dest), sizeof(fastd_eth_addr_t));
 	return ret;
@@ -475,12 +475,12 @@ static inline fastd_eth_addr_t fastd_buffer_dest_address(const fastd_buffer_t *b
 
 
 /** Checks if a fastd_peer_address_t is an IPv6 link-local address */
-static inline bool fastd_peer_address_is_v6_ll(const fastd_peer_address_t *addr) {
+static inline bool fastd_peer_address_is_v6_ll(const fastd_peer_address_t * const addr) {
 	return (addr->sa.sa_family == AF_INET6 && IN6_IS_ADDR_LINKLOCAL(&addr->in6.sin6_addr));
 }
 
 /** Duplicates a string, creating a one-element string stack */
-static inline fastd_string_stack_t *fastd_string_stack_dup(const char *str) {
+static inline fastd_string_stack_t *fastd_string_stack_dup(const char * const str) {
 	size_t str_len = strlen(str);
 	fastd_string_stack_t *ret = fastd_alloc(alignto(sizeof(fastd_string_stack_t) + str_len + 1, 8));
 
@@ -492,7 +492,7 @@ static inline fastd_string_stack_t *fastd_string_stack_dup(const char *str) {
 }
 
 /** Duplicates a string of a given maximum length, creating a one-element string stack */
-static inline fastd_string_stack_t *fastd_string_stack_dupn(const char *str, size_t len) {
+static inline fastd_string_stack_t *fastd_string_stack_dupn(const char * const str, const size_t len) {
 	size_t str_len = strnlen(str, len);
 	fastd_string_stack_t *ret = fastd_alloc(alignto(sizeof(fastd_string_stack_t) + str_len + 1, 8));
 
@@ -505,7 +505,7 @@ static inline fastd_string_stack_t *fastd_string_stack_dupn(const char *str, siz
 }
 
 /** Pushes the copy of a string onto the top of a string stack */
-static inline fastd_string_stack_t *fastd_string_stack_push(fastd_string_stack_t *stack, const char *str) {
+static inline fastd_string_stack_t *fastd_string_stack_push(fastd_string_stack_t * const stack, const char * const str) {
 	size_t str_len = strlen(str);
 	fastd_string_stack_t *ret = fastd_alloc(alignto(sizeof(fastd_string_stack_t) + str_len + 1, 8));
 
@@ -517,7 +517,7 @@ static inline fastd_string_stack_t *fastd_string_stack_push(fastd_string_stack_t
 }
 
 /** Gets the head of string stack (or NULL if the stack is NULL) */
-static inline const char *fastd_string_stack_get(const fastd_string_stack_t *stack) {
+static inline const char *fastd_string_stack_get(const fastd_string_stack_t * const stack) {
 	return stack ? stack->str : NULL;
 }
 
@@ -551,12 +551,12 @@ static inline void fastd_string_stack_free(fastd_string_stack_t *str) {
 
    \note The current time is updated only once per main loop iteration, after waiting for input.
 */
-static inline bool fastd_timed_out(fastd_timeout_t timeout) {
+static inline bool fastd_timed_out(const fastd_timeout_t timeout) {
 	return timeout <= ctx.now;
 }
 
 /** Returns the minimum of two fastd_timeout_t values */
-static inline fastd_timeout_t fastd_timeout_min(fastd_timeout_t a, fastd_timeout_t b) {
+static inline fastd_timeout_t fastd_timeout_min(const fastd_timeout_t a, const fastd_timeout_t b) {
 	return (a < b) ? a : b;
 }
 

--- a/src/handshake.c
+++ b/src/handshake.c
@@ -40,27 +40,27 @@ static const char *const RECORD_TYPES[RECORD_MAX] = {
 
 
 /** Reads a TLV record as an 8bit integer */
-static inline uint8_t as_uint8(const fastd_handshake_record_t *record) {
+static inline uint8_t as_uint8(const fastd_handshake_record_t * const record) {
 	return record->data[0];
 }
 
 /** Reads a TLV record as a 16bit integer (little endian) */
-static inline uint16_t as_uint16(const fastd_handshake_record_t *record) {
+static inline uint16_t as_uint16(const fastd_handshake_record_t * const record) {
 	return (uint16_t)record->data[1] << 8 | as_uint8(record);
 }
 
 /** Reads a TLV record as a 24bit integer (little endian) */
-static inline uint32_t as_uint24(const fastd_handshake_record_t *record) {
+static inline uint32_t as_uint24(const fastd_handshake_record_t * const record) {
 	return (uint32_t)record->data[2] << 16 | as_uint16(record);
 }
 
 /** Reads a TLV record as a 32bit integer (little endian) */
-static inline uint32_t as_uint32(const fastd_handshake_record_t *record) {
+static inline uint32_t as_uint32(const fastd_handshake_record_t * const record) {
 	return (uint32_t)record->data[3] << 24 | as_uint24(record);
 }
 
 /** Reads a TLV record as a variable-length integer (little endian) */
-static inline uint32_t as_uint(const fastd_handshake_record_t *record) {
+static inline uint32_t as_uint(const fastd_handshake_record_t * const record) {
 	switch (record->length) {
 	case 0:
 		return 0;
@@ -94,7 +94,7 @@ static inline uint8_t get_mode_id(void) {
 }
 
 /** Generates a zero-separated list of supported methods */
-static uint8_t *create_method_list(const fastd_string_stack_t *methods, size_t *len) {
+static uint8_t *create_method_list(const fastd_string_stack_t * const methods, size_t * const len) {
 	size_t n = 0, i;
 	const fastd_string_stack_t *method;
 	for (method = methods; method; method = method->next)
@@ -122,7 +122,7 @@ static uint8_t *create_method_list(const fastd_string_stack_t *methods, size_t *
 }
 
 /** Checks if a string is equal to a buffer with a maximum length */
-static inline bool string_equal(const char *str, const char *buf, size_t maxlen) {
+static inline bool string_equal(const char * const str, const char * const buf, const size_t maxlen) {
 	if (strlen(str) != strnlen(buf, maxlen))
 		return false;
 
@@ -130,20 +130,22 @@ static inline bool string_equal(const char *str, const char *buf, size_t maxlen)
 }
 
 /** Checks if a string is equal to the value of a TLV record */
-static inline bool record_equal(const char *str, const fastd_handshake_record_t *record) {
+static inline bool record_equal(const char * const str, const fastd_handshake_record_t * const record) {
 	return string_equal(str, (const char *)record->data, record->length);
 }
 
 /** Parses a list of zero-separated strings */
-static fastd_string_stack_t *parse_string_list(const uint8_t *data, size_t len) {
+static fastd_string_stack_t *parse_string_list(const uint8_t * const data, const size_t len) {
 	const uint8_t *end = data + len;
 	fastd_string_stack_t *ret = NULL;
 
-	while (data < end) {
+	for (const uint8_t* data_iterator=data;
+	     data_iterator < end;
+	     ) {
 		fastd_string_stack_t *part = fastd_string_stack_dupn((char *)data, end - data);
 		part->next = ret;
 		ret = part;
-		data += strlen(part->str) + 1;
+		data_iterator += strlen(part->str) + 1;
 	}
 
 	return ret;
@@ -151,11 +153,11 @@ static fastd_string_stack_t *parse_string_list(const uint8_t *data, size_t len) 
 
 /** Allocates and initializes a new handshake packet */
 static fastd_buffer_t *new_handshake(
-	uint8_t type, uint16_t mtu, const fastd_method_info_t *method, const fastd_string_stack_t *methods,
-	size_t tail_space) {
-	size_t version_len = strlen(FASTD_VERSION);
-	size_t protocol_len = strlen(conf.protocol->name);
-	size_t method_len = method ? strlen(method->name) : 0;
+	uint8_t type, const uint16_t mtu, const fastd_method_info_t * const method, const fastd_string_stack_t * const methods,
+	const size_t tail_space) {
+	const size_t version_len = strlen(FASTD_VERSION);
+	const size_t protocol_len = strlen(conf.protocol->name);
+	const size_t method_len = method ? strlen(method->name) : 0;
 
 	size_t method_list_len = 0;
 	uint8_t *method_list = NULL;
@@ -204,14 +206,14 @@ static fastd_buffer_t *new_handshake(
 }
 
 /** Allocates and initializes a new initial handshake packet */
-fastd_buffer_t *fastd_handshake_new_init(size_t tail_space) {
+fastd_buffer_t *fastd_handshake_new_init(const size_t tail_space) {
 	return new_handshake(1, 0, NULL, NULL, tail_space);
 }
 
 /** Allocates and initializes a new reply handshake packet */
 fastd_buffer_t *fastd_handshake_new_reply(
-	uint8_t type, uint16_t mtu, const fastd_method_info_t *method, const fastd_string_stack_t *methods,
-	size_t tail_space) {
+	const const uint8_t type, const uint16_t mtu, const fastd_method_info_t * const method, const fastd_string_stack_t * const methods,
+	const size_t tail_space) {
 	fastd_buffer_t *buffer = new_handshake(type, mtu, method, methods, tail_space);
 	fastd_handshake_add_uint8(buffer, RECORD_REPLY_CODE, 0);
 	return buffer;
@@ -219,8 +221,8 @@ fastd_buffer_t *fastd_handshake_new_reply(
 
 /** Prints the error corresponding to the given reply code and error detail */
 static void print_error(
-	const char *prefix, const fastd_peer_t *peer, const fastd_peer_address_t *remote_addr, uint8_t reply_code,
-	uint16_t error_detail) {
+	const char * const prefix, const fastd_peer_t * const peer, const fastd_peer_address_t * const remote_addr, const uint8_t reply_code,
+	const uint16_t error_detail) {
 	const char *error_field_str;
 
 	if (error_detail >= RECORD_MAX)
@@ -273,8 +275,8 @@ static void print_error(
 
 /** Sends an error reply to a peer */
 void fastd_handshake_send_error(
-	fastd_socket_t *sock, const fastd_peer_address_t *local_addr, const fastd_peer_address_t *remote_addr,
-	fastd_peer_t *peer, const fastd_handshake_t *handshake, uint8_t reply_code, uint16_t error_detail) {
+	fastd_socket_t * const sock, const fastd_peer_address_t * const local_addr, const fastd_peer_address_t * const remote_addr,
+	fastd_peer_t * const peer, const fastd_handshake_t * const handshake, const uint8_t reply_code, const uint16_t error_detail) {
 	print_error("sending", peer, remote_addr, reply_code, error_detail);
 
 	fastd_buffer_t *buffer = fastd_buffer_alloc(
@@ -296,13 +298,13 @@ void fastd_handshake_send_error(
 }
 
 /** Parses the TLV records of a handshake */
-static inline fastd_handshake_t parse_tlvs(const fastd_buffer_t *buffer) {
+static inline fastd_handshake_t parse_tlvs(const fastd_buffer_t * const buffer) {
 	fastd_handshake_t handshake = {};
 
 	if (buffer->len < sizeof(fastd_handshake_packet_t))
 		return handshake;
 
-	fastd_handshake_packet_t *packet = buffer->data;
+	fastd_handshake_packet_t * const packet = buffer->data;
 
 	size_t tlv_len = fastd_handshake_tlv_len(buffer);
 	if (buffer->len < sizeof(fastd_handshake_packet_t) + tlv_len)
@@ -337,8 +339,8 @@ static inline fastd_handshake_t parse_tlvs(const fastd_buffer_t *buffer) {
 
 /** Prints the error found in a received handshake */
 static inline void print_error_reply(
-	const fastd_peer_t *peer, const fastd_peer_address_t *remote_addr, const fastd_handshake_t *handshake) {
-	uint8_t reply_code = as_uint8(&handshake->records[RECORD_REPLY_CODE]);
+	const fastd_peer_t * const peer, const fastd_peer_address_t * const remote_addr, const fastd_handshake_t * const handshake) {
+	const uint8_t reply_code = as_uint8(&handshake->records[RECORD_REPLY_CODE]);
 	uint16_t error_detail = RECORD_MAX;
 
 	if (handshake->records[RECORD_ERROR_DETAIL].length == 1 || handshake->records[RECORD_ERROR_DETAIL].length == 2)
@@ -349,8 +351,8 @@ static inline void print_error_reply(
 
 /** Does some basic validity checks on a received handshake */
 static inline bool check_records(
-	fastd_socket_t *sock, const fastd_peer_address_t *local_addr, const fastd_peer_address_t *remote_addr,
-	fastd_peer_t *peer, const fastd_handshake_t *handshake) {
+	fastd_socket_t * const sock, const fastd_peer_address_t * const local_addr, const fastd_peer_address_t * const remote_addr,
+	fastd_peer_t * const peer, const fastd_handshake_t * const handshake) {
 	if (handshake->records[RECORD_PROTOCOL_NAME].data) {
 		if (!record_equal(conf.protocol->name, &handshake->records[RECORD_PROTOCOL_NAME])) {
 			fastd_handshake_send_error(
@@ -386,8 +388,8 @@ static inline bool check_records(
 
 /** Checks if an MTU record of a handshake matches the configured MTU for a peer */
 bool fastd_handshake_check_mtu(
-	fastd_socket_t *sock, const fastd_peer_address_t *local_addr, const fastd_peer_address_t *remote_addr,
-	fastd_peer_t *peer, const fastd_handshake_t *handshake) {
+	fastd_socket_t * const sock, const fastd_peer_address_t * const local_addr, const fastd_peer_address_t * const remote_addr,
+	fastd_peer_t * const peer, const fastd_handshake_t * const handshake) {
 	if (handshake->records[RECORD_MTU].length == 2) {
 		if (as_uint16(&handshake->records[RECORD_MTU]) != fastd_peer_get_mtu(peer)) {
 			fastd_handshake_send_error(
@@ -401,7 +403,7 @@ bool fastd_handshake_check_mtu(
 
 /** Returns the method info with a specified name and length */
 static inline const fastd_method_info_t *
-get_method_by_name(const fastd_string_stack_t *methods, const char *name, size_t n) {
+get_method_by_name(const fastd_string_stack_t * const methods, const char * const name, const size_t n) {
 	char name0[n + 1];
 	memcpy(name0, name, n);
 	name0[n] = 0;
@@ -414,7 +416,7 @@ get_method_by_name(const fastd_string_stack_t *methods, const char *name, size_t
 
 /** Returns the most appropriate method to negotiate with a peer a handshake was received from */
 const fastd_method_info_t *
-fastd_handshake_get_method_by_name_list(const fastd_peer_t *peer, const fastd_handshake_t *handshake) {
+fastd_handshake_get_method_by_name_list(const fastd_peer_t * const peer, const fastd_handshake_t * const handshake) {
 	const fastd_string_stack_t *methods = *fastd_peer_group_lookup_peer(peer, methods);
 
 	if (!handshake->records[RECORD_METHOD_LIST].data || !handshake->records[RECORD_METHOD_LIST].length)
@@ -441,11 +443,11 @@ fastd_handshake_get_method_by_name_list(const fastd_peer_t *peer, const fastd_ha
 }
 
 const fastd_method_info_t *
-fastd_handshake_get_method_by_name(const fastd_peer_t *peer, const fastd_handshake_t *handshake) {
+fastd_handshake_get_method_by_name(const fastd_peer_t * const peer, const fastd_handshake_t * const handshake) {
 	if (!handshake->records[RECORD_METHOD_NAME].data)
 		return NULL;
 
-	const fastd_string_stack_t *methods = *fastd_peer_group_lookup_peer(peer, methods);
+	const fastd_string_stack_t * const methods = *fastd_peer_group_lookup_peer(peer, methods);
 
 	return get_method_by_name(
 		methods, (const char *)handshake->records[RECORD_METHOD_NAME].data,
@@ -454,8 +456,8 @@ fastd_handshake_get_method_by_name(const fastd_peer_t *peer, const fastd_handsha
 
 /** Handles a handshake packet */
 void fastd_handshake_handle(
-	fastd_socket_t *sock, const fastd_peer_address_t *local_addr, const fastd_peer_address_t *remote_addr,
-	fastd_peer_t *peer, fastd_buffer_t *buffer) {
+	fastd_socket_t * const sock, const fastd_peer_address_t * const local_addr, const fastd_peer_address_t * const remote_addr,
+	fastd_peer_t * const peer, fastd_buffer_t * const buffer) {
 	char *peer_version = NULL;
 
 	fastd_handshake_t handshake = parse_tlvs(buffer);

--- a/src/handshake.h
+++ b/src/handshake.h
@@ -87,42 +87,42 @@ struct fastd_handshake {
 };
 
 
-fastd_buffer_t *fastd_handshake_new_init(size_t tail_space);
+fastd_buffer_t *fastd_handshake_new_init(const size_t tail_space);
 fastd_buffer_t *fastd_handshake_new_reply(
-	uint8_t type, uint16_t mtu, const fastd_method_info_t *method, const fastd_string_stack_t *methods,
-	size_t tail_space);
+	const uint8_t type, const uint16_t mtu, const fastd_method_info_t * const method, const fastd_string_stack_t * const methods,
+	const size_t tail_space);
 
 void fastd_handshake_send_error(
-	fastd_socket_t *sock, const fastd_peer_address_t *local_addr, const fastd_peer_address_t *remote_addr,
-	fastd_peer_t *peer, const fastd_handshake_t *handshake, uint8_t reply_code, uint16_t error_detail);
+	fastd_socket_t * const sock, const fastd_peer_address_t * const local_addr, const fastd_peer_address_t * const remote_addr,
+	fastd_peer_t * const peer, const fastd_handshake_t * const handshake, const uint8_t reply_code, const uint16_t error_detail);
 bool fastd_handshake_check_mtu(
-	fastd_socket_t *sock, const fastd_peer_address_t *local_addr, const fastd_peer_address_t *remote_addr,
-	fastd_peer_t *peer, const fastd_handshake_t *handshake);
+	fastd_socket_t * const sock, const fastd_peer_address_t * const local_addr, const fastd_peer_address_t * const remote_addr,
+	fastd_peer_t * const peer, const fastd_handshake_t * const handshake);
 
 const fastd_method_info_t *
-fastd_handshake_get_method_by_name_list(const fastd_peer_t *peer, const fastd_handshake_t *handshake);
+fastd_handshake_get_method_by_name_list(const fastd_peer_t * const peer, const fastd_handshake_t * const handshake);
 const fastd_method_info_t *
-fastd_handshake_get_method_by_name(const fastd_peer_t *peer, const fastd_handshake_t *handshake);
+fastd_handshake_get_method_by_name(const fastd_peer_t * const peer, const fastd_handshake_t * const handshake);
 
 void fastd_handshake_handle(
-	fastd_socket_t *sock, const fastd_peer_address_t *local_addr, const fastd_peer_address_t *remote_addr,
-	fastd_peer_t *peer, fastd_buffer_t *buffer);
+	fastd_socket_t * const sock, const fastd_peer_address_t * const local_addr, const fastd_peer_address_t * const remote_addr,
+	fastd_peer_t * const peer, fastd_buffer_t * const buffer);
 
 
 /** Returns the TLV data of a handshake packet in a given buffer */
-static inline void *fastd_handshake_tlv_data(const fastd_buffer_t *buffer) {
-	fastd_handshake_packet_t *packet = buffer->data;
+static inline void *fastd_handshake_tlv_data(const fastd_buffer_t * const buffer) {
+	fastd_handshake_packet_t * const packet = buffer->data;
 	return packet->tlv_data;
 }
 
 /** Returns the length the TLV data of a handshake packet in a given buffer */
-static inline uint16_t fastd_handshake_tlv_len(const fastd_buffer_t *buffer) {
-	fastd_handshake_packet_t *packet = buffer->data;
+static inline uint16_t fastd_handshake_tlv_len(const fastd_buffer_t * const buffer) {
+	const fastd_handshake_packet_t * const packet = buffer->data;
 	return ntohs(packet->tlv_len);
 }
 
 /** Adds an uninitialized TLV record of given type and length to a handshake buffer */
-static inline uint8_t *fastd_handshake_extend(fastd_buffer_t *buffer, fastd_handshake_record_type_t type, size_t len) {
+static inline uint8_t *fastd_handshake_extend(fastd_buffer_t * const buffer, const fastd_handshake_record_type_t type, const size_t len) {
 	uint8_t *dst = buffer->data + buffer->len;
 
 	if ((uint8_t *)buffer->data + buffer->len + RECORD_LEN(len) > buffer->base + ctx.max_buffer)
@@ -143,7 +143,7 @@ static inline uint8_t *fastd_handshake_extend(fastd_buffer_t *buffer, fastd_hand
 
 /** Adds an TLV record of given type and length initialized with arbitraty data to a handshake buffer */
 static inline void
-fastd_handshake_add(fastd_buffer_t *buffer, fastd_handshake_record_type_t type, size_t len, const void *data) {
+fastd_handshake_add(fastd_buffer_t * const buffer, const fastd_handshake_record_type_t type, const size_t len, const void * const data) {
 	uint8_t *dst = fastd_handshake_extend(buffer, type, len);
 
 	memcpy(dst, data, len);
@@ -151,7 +151,7 @@ fastd_handshake_add(fastd_buffer_t *buffer, fastd_handshake_record_type_t type, 
 
 /** Adds an TLV record of given type and length initialized with zeros to a handshake buffer */
 static inline uint8_t *
-fastd_handshake_add_zero(fastd_buffer_t *buffer, fastd_handshake_record_type_t type, size_t len) {
+fastd_handshake_add_zero(fastd_buffer_t * const buffer, const fastd_handshake_record_type_t type, const size_t len) {
 	uint8_t *dst = fastd_handshake_extend(buffer, type, len);
 
 	memset(dst, 0, len);
@@ -160,7 +160,7 @@ fastd_handshake_add_zero(fastd_buffer_t *buffer, fastd_handshake_record_type_t t
 
 /** Adds an uint8 TLV record of given type and value to a handshake buffer */
 static inline void
-fastd_handshake_add_uint8(fastd_buffer_t *buffer, fastd_handshake_record_type_t type, uint8_t value) {
+fastd_handshake_add_uint8(fastd_buffer_t * const buffer, const fastd_handshake_record_type_t type, const uint8_t value) {
 	uint8_t *dst = fastd_handshake_extend(buffer, type, 1);
 
 	dst[0] = value;
@@ -168,7 +168,7 @@ fastd_handshake_add_uint8(fastd_buffer_t *buffer, fastd_handshake_record_type_t 
 
 /** Adds an uint16 TLV record of given type and value to a handshake buffer */
 static inline void
-fastd_handshake_add_uint16(fastd_buffer_t *buffer, fastd_handshake_record_type_t type, uint16_t value) {
+fastd_handshake_add_uint16(fastd_buffer_t * const buffer, const fastd_handshake_record_type_t type, const uint16_t value) {
 	uint8_t *dst = fastd_handshake_extend(buffer, type, 2);
 
 	dst[0] = value;
@@ -177,7 +177,7 @@ fastd_handshake_add_uint16(fastd_buffer_t *buffer, fastd_handshake_record_type_t
 
 /** Adds an uint24 TLV record of given type and value to a handshake buffer */
 static inline void
-fastd_handshake_add_uint24(fastd_buffer_t *buffer, fastd_handshake_record_type_t type, uint32_t value) {
+fastd_handshake_add_uint24(fastd_buffer_t * const buffer, const fastd_handshake_record_type_t type, const uint32_t value) {
 	uint8_t *dst = fastd_handshake_extend(buffer, type, 3);
 
 	dst[0] = value;
@@ -187,7 +187,7 @@ fastd_handshake_add_uint24(fastd_buffer_t *buffer, fastd_handshake_record_type_t
 
 /** Adds an uint32 TLV record of given type and value to a handshake buffer */
 static inline void
-fastd_handshake_add_uint32(fastd_buffer_t *buffer, fastd_handshake_record_type_t type, uint32_t value) {
+fastd_handshake_add_uint32(fastd_buffer_t * const buffer, const fastd_handshake_record_type_t type, const uint32_t value) {
 	uint8_t *dst = fastd_handshake_extend(buffer, type, 4);
 
 	dst[0] = value;
@@ -198,7 +198,7 @@ fastd_handshake_add_uint32(fastd_buffer_t *buffer, fastd_handshake_record_type_t
 
 /** Adds an TLV record of given type and value to a handshake buffer, automatically using a 1- to 4-byte value */
 static inline void
-fastd_handshake_add_uint(fastd_buffer_t *buffer, fastd_handshake_record_type_t type, uint32_t value) {
+fastd_handshake_add_uint(fastd_buffer_t * const buffer, const fastd_handshake_record_type_t type, const  uint32_t value) {
 	if (value > 0xffffff)
 		fastd_handshake_add_uint32(buffer, type, value);
 	else if (value > 0xffff)

--- a/src/hash.h
+++ b/src/hash.h
@@ -21,7 +21,7 @@
 
 
 /** Adds data bytes to the 32bit hash value */
-static inline void fastd_hash(uint32_t *hash, const void *data, size_t len) {
+static inline void fastd_hash(uint32_t * const hash, const void *data, const size_t len) {
 	size_t i;
 	for (i = 0; i < len; ++i) {
 		*hash += ((uint8_t *)data)[i];
@@ -31,7 +31,7 @@ static inline void fastd_hash(uint32_t *hash, const void *data, size_t len) {
 }
 
 /** Finalizes a hash value */
-static inline void fastd_hash_final(uint32_t *hash) {
+static inline void fastd_hash_final(uint32_t * const hash) {
 	*hash += (*hash << 3);
 	*hash ^= (*hash >> 11);
 	*hash += (*hash << 15);

--- a/src/iface.c
+++ b/src/iface.c
@@ -69,14 +69,14 @@ static inline fastd_iface_type_t get_iface_type(void) {
 	}
 }
 
-static bool open_iface(fastd_iface_t *iface, const char *ifname, uint16_t mtu);
-static void cleanup_iface(fastd_iface_t *iface);
+static bool open_iface(fastd_iface_t * const iface, const char * const ifname, const uint16_t mtu);
+static void cleanup_iface(fastd_iface_t * const iface);
 
 
 #ifdef __linux__
 
 /** Opens the TUN/TAP device helper shared by Android and Linux targets */
-static bool open_iface_linux(fastd_iface_t *iface, const char *ifname, uint16_t mtu, const char *dev_name) {
+static bool open_iface_linux(fastd_iface_t * const iface, const char * const ifname, const uint16_t mtu, const char * const dev_name) {
 	struct ifreq ifr = {};
 
 	iface->fd = FASTD_POLL_FD(POLL_TYPE_IFACE, open(dev_name, O_RDWR | O_NONBLOCK));
@@ -122,14 +122,14 @@ static bool open_iface_linux(fastd_iface_t *iface, const char *ifname, uint16_t 
 }
 
 /** Removes TUN/TAP interfaces on platforms which need this */
-static void cleanup_iface(UNUSED fastd_iface_t *iface) {}
+static void cleanup_iface(UNUSED fastd_iface_t * const iface) {}
 
 #endif
 
 #if defined(__ANDROID__)
 
 /** Opens the TUN/TAP device */
-static bool open_iface(fastd_iface_t *iface, const char *ifname, uint16_t mtu) {
+static bool open_iface(fastd_iface_t *iface, const char * const ifname, const uint16_t mtu) {
 	if (conf.android_integration) {
 		if (get_iface_type() != IFACE_TYPE_TUN)
 			exit_bug("Non-TUN iface type with Android integration");
@@ -148,14 +148,14 @@ static bool open_iface(fastd_iface_t *iface, const char *ifname, uint16_t mtu) {
 #elif defined(__linux__)
 
 /** Opens the TUN/TAP device */
-static bool open_iface(fastd_iface_t *iface, const char *ifname, uint16_t mtu) {
+static bool open_iface(fastd_iface_t * const iface, const char * const ifname, const uint16_t mtu) {
 	return open_iface_linux(iface, ifname, mtu, "/dev/net/tun");
 }
 
 #elif defined(__FreeBSD__) || defined(__OpenBSD__)
 
 /** Sets the MTU of the TUN/TAP device */
-static bool set_tun_mtu(fastd_iface_t *iface, uint16_t mtu) {
+static bool set_tun_mtu(fastd_iface_t * const iface, const uint16_t mtu) {
 	struct tuninfo tuninfo;
 
 	if (ioctl(iface->fd.fd, TUNGIFINFO, &tuninfo) < 0)
@@ -174,7 +174,7 @@ static bool set_tun_mtu(fastd_iface_t *iface, uint16_t mtu) {
 #ifdef __FreeBSD__
 
 /** Sets the MTU of the TAP device */
-static bool set_tap_mtu(fastd_iface_t *iface, uint16_t mtu) {
+static bool set_tap_mtu(fastd_iface_t * const iface, const uint16_t mtu) {
 	struct tapinfo tapinfo;
 
 	if (ioctl(iface->fd.fd, TAPGIFINFO, &tapinfo) < 0)
@@ -191,7 +191,7 @@ static bool set_tap_mtu(fastd_iface_t *iface, uint16_t mtu) {
 }
 
 /** Sets up the TUN device */
-static bool setup_tun(fastd_iface_t *iface, uint16_t mtu) {
+static bool setup_tun(fastd_iface_t * const iface, const uint16_t mtu) {
 	int one = 1;
 	if (ioctl(iface->fd.fd, TUNSIFHEAD, &one) < 0) {
 		pr_error_errno("TUNSIFHEAD ioctl failed");
@@ -202,7 +202,7 @@ static bool setup_tun(fastd_iface_t *iface, uint16_t mtu) {
 }
 
 /** Sets up the TAP device */
-static bool setup_tap(fastd_iface_t *iface, uint16_t mtu) {
+static bool setup_tap(fastd_iface_t * const iface, const uint16_t mtu) {
 	struct ifreq ifr = {};
 
 	if (ioctl(iface->fd.fd, TAPGIFNAME, &ifr) < 0)
@@ -215,7 +215,7 @@ static bool setup_tap(fastd_iface_t *iface, uint16_t mtu) {
 }
 
 /** Opens the TUN/TAP device */
-static bool open_iface(fastd_iface_t *iface, const char *ifname, uint16_t mtu) {
+static bool open_iface(fastd_iface_t * const iface, const char * const ifname, const uint16_t mtu) {
 	char dev_name[5 + IFNAMSIZ] = "/dev/";
 	const char *type;
 	bool cleanup = true;
@@ -277,7 +277,7 @@ static bool open_iface(fastd_iface_t *iface, const char *ifname, uint16_t mtu) {
 }
 
 /** Removes TUN/TAP interfaces on platforms which need this */
-static void cleanup_iface(fastd_iface_t *iface) {
+static void cleanup_iface(fastd_iface_t * const iface) {
 	if (!iface->cleanup)
 		return;
 
@@ -291,7 +291,7 @@ static void cleanup_iface(fastd_iface_t *iface) {
 #else /* __OpenBSD__ */
 
 /** Opens the TUN/TAP device */
-static bool open_iface(fastd_iface_t *iface, const char *ifname, uint16_t mtu) {
+static bool open_iface(fastd_iface_t * const iface, const char * const ifname, const uint16_t mtu) {
 	if (!ifname) {
 		pr_error("config error: no interface name given.");
 		return false;
@@ -334,14 +334,14 @@ static bool open_iface(fastd_iface_t *iface, const char *ifname, uint16_t mtu) {
 }
 
 /** Removes TUN/TAP interfaces on platforms which need this */
-static void cleanup_iface(UNUSED fastd_iface_t *iface) {}
+static void cleanup_iface(UNUSED fastd_iface_t * const iface) {}
 
 #endif
 
 #elif __APPLE__
 
 /** Opens the TUN/TAP device */
-static bool open_iface(fastd_iface_t *iface, const char *ifname, uint16_t mtu) {
+static bool open_iface(fastd_iface_t * const iface, const char * const ifname, const uint16_t mtu) {
 	const char *devtype;
 	switch (get_iface_type()) {
 	case IFACE_TYPE_TAP:
@@ -387,7 +387,7 @@ static bool open_iface(fastd_iface_t *iface, const char *ifname, uint16_t mtu) {
 }
 
 /** Removes TUN/TAP interfaces on platforms which need this */
-static void cleanup_iface(UNUSED fastd_iface_t *iface) {}
+static void cleanup_iface(UNUSED fastd_iface_t * const iface) {}
 
 #else
 
@@ -397,7 +397,7 @@ static void cleanup_iface(UNUSED fastd_iface_t *iface) {}
 
 
 /** Reads a packet from the TUN/TAP device */
-void fastd_iface_handle(fastd_iface_t *iface) {
+void fastd_iface_handle(const fastd_iface_t * const iface) {
 	size_t max_len = fastd_max_payload(iface->mtu);
 
 	fastd_buffer_t *buffer;
@@ -419,7 +419,7 @@ void fastd_iface_handle(fastd_iface_t *iface) {
 }
 
 /** Writes a packet to the TUN/TAP device */
-void fastd_iface_write(fastd_iface_t *iface, fastd_buffer_t *buffer) {
+void fastd_iface_write(const fastd_iface_t * const iface, fastd_buffer_t * const buffer) {
 	if (!buffer->len) {
 		pr_debug("fastd_iface_write: truncated packet");
 		return;
@@ -451,7 +451,7 @@ void fastd_iface_write(fastd_iface_t *iface, fastd_buffer_t *buffer) {
 }
 
 /** Opens a new TUN/TAP interface, optionally associated with a specific peer */
-fastd_iface_t *fastd_iface_open(fastd_peer_t *peer) {
+fastd_iface_t *fastd_iface_open(fastd_peer_t * const peer) {
 	const char *ifname = conf.ifname;
 	char ifnamebuf[IFNAMSIZ];
 
@@ -530,7 +530,7 @@ fastd_iface_t *fastd_iface_open(fastd_peer_t *peer) {
 }
 
 /** Closes the TUN/TAP device */
-void fastd_iface_close(fastd_iface_t *iface) {
+void fastd_iface_close(fastd_iface_t * const iface) {
 	if (fastd_poll_fd_close(&iface->fd))
 		cleanup_iface(iface);
 	else

--- a/src/lex.c
+++ b/src/lex.c
@@ -116,14 +116,14 @@ static const keyword_t keywords[] = {
 };
 
 /** Compares two keyword_t instances by their keyword */
-static int compare_keywords(const void *v1, const void *v2) {
+static int compare_keywords(const void * const v1, const void * const v2) {
 	const keyword_t *k1 = v1, *k2 = v2;
 	return strcmp(k1->keyword, k2->keyword);
 }
 
 
 /** Reads the next part of the input file into the input buffer */
-static bool advance(fastd_lex_t *lex) {
+static bool advance(fastd_lex_t * const lex) {
 	if (lex->start > 0) {
 		memmove(lex->buffer, lex->buffer + lex->start, lex->end - lex->start);
 		lex->end -= lex->start;
@@ -140,17 +140,17 @@ static bool advance(fastd_lex_t *lex) {
 }
 
 /** Returns the current character (not yet added to the current token) */
-static inline char current(fastd_lex_t *lex) {
+static inline char current(fastd_lex_t * const lex) {
 	return lex->buffer[lex->start + lex->tok_len];
 }
 
 /** Returns the current token as a newly allocated string */
-static char *get_token(fastd_lex_t *lex) {
+static char *get_token(fastd_lex_t * const lex) {
 	return fastd_strndup(lex->buffer + lex->start, lex->tok_len);
 }
 
 /** Tries to add the next character to the current token */
-static bool next(FASTD_CONFIG_LTYPE *yylloc, fastd_lex_t *lex, bool move) {
+static bool next(FASTD_CONFIG_LTYPE * const yylloc, fastd_lex_t * const lex, const bool move) {
 	if (lex->start + lex->tok_len >= lex->end)
 		return false;
 
@@ -174,7 +174,7 @@ static bool next(FASTD_CONFIG_LTYPE *yylloc, fastd_lex_t *lex, bool move) {
 }
 
 /** Removes the current token from the input buffer */
-static void consume(fastd_lex_t *lex, bool needspace) {
+static void consume(fastd_lex_t * const lex, const bool needspace) {
 	lex->start += lex->tok_len;
 	lex->tok_len = 0;
 
@@ -182,13 +182,13 @@ static void consume(fastd_lex_t *lex, bool needspace) {
 }
 
 /** Signals an error caused by an I/O error */
-static int io_error(FASTD_CONFIG_STYPE *yylval, UNUSED fastd_lex_t *lex) {
+static int io_error(FASTD_CONFIG_STYPE * const yylval, UNUSED const fastd_lex_t * const lex) {
 	yylval->error = "I/O error";
 	return -1;
 }
 
 /** Signals an error caused by a syntax error */
-static int syntax_error(FASTD_CONFIG_STYPE *yylval, fastd_lex_t *lex) {
+static int syntax_error(FASTD_CONFIG_STYPE * const yylval, const fastd_lex_t * const lex) {
 	if (ferror(lex->file))
 		return io_error(yylval, lex);
 
@@ -197,7 +197,7 @@ static int syntax_error(FASTD_CONFIG_STYPE *yylval, fastd_lex_t *lex) {
 }
 
 /** Skips a block comment */
-static int consume_comment(FASTD_CONFIG_STYPE *yylval, FASTD_CONFIG_LTYPE *yylloc, fastd_lex_t *lex) {
+static int consume_comment(FASTD_CONFIG_STYPE * const yylval, FASTD_CONFIG_LTYPE * const yylloc, fastd_lex_t * const lex) {
 	char prev = 0;
 
 	while (next(yylloc, lex, true)) {
@@ -218,7 +218,7 @@ static int consume_comment(FASTD_CONFIG_STYPE *yylval, FASTD_CONFIG_LTYPE *yyllo
 }
 
 /** Signals an error caused by an unterminated string */
-static int unterminated_string(FASTD_CONFIG_STYPE *yylval, fastd_lex_t *lex) {
+static int unterminated_string(FASTD_CONFIG_STYPE * const yylval, fastd_lex_t * const lex) {
 	if (ferror(lex->file))
 		return io_error(yylval, lex);
 
@@ -227,7 +227,7 @@ static int unterminated_string(FASTD_CONFIG_STYPE *yylval, fastd_lex_t *lex) {
 }
 
 /** Tries to process the current input as a string */
-static int parse_string(FASTD_CONFIG_STYPE *yylval, FASTD_CONFIG_LTYPE *yylloc, fastd_lex_t *lex) {
+static int parse_string(FASTD_CONFIG_STYPE * const yylval, FASTD_CONFIG_LTYPE * const yylloc, fastd_lex_t * const lex) {
 	char *buf = NULL;
 	size_t len = 1024;
 	size_t pos = 0;
@@ -278,7 +278,7 @@ static int parse_string(FASTD_CONFIG_STYPE *yylval, FASTD_CONFIG_LTYPE *yylloc, 
 }
 
 /** Tries to process the current input as an IPv6 address */
-static int parse_ipv6_address(FASTD_CONFIG_STYPE *yylval, FASTD_CONFIG_LTYPE *yylloc, fastd_lex_t *lex) {
+static int parse_ipv6_address(FASTD_CONFIG_STYPE * const yylval, FASTD_CONFIG_LTYPE * const yylloc, fastd_lex_t * const lex) {
 	if (lex->needspace)
 		return syntax_error(yylval, lex);
 
@@ -345,7 +345,7 @@ static int parse_ipv6_address(FASTD_CONFIG_STYPE *yylval, FASTD_CONFIG_LTYPE *yy
 }
 
 /** Tries to process the current input as an IPv4 address */
-static int parse_ipv4_address(FASTD_CONFIG_STYPE *yylval, FASTD_CONFIG_LTYPE *yylloc, fastd_lex_t *lex) {
+static int parse_ipv4_address(FASTD_CONFIG_STYPE * const yylval, FASTD_CONFIG_LTYPE * const yylloc, fastd_lex_t * const lex) {
 	if (lex->needspace)
 		return syntax_error(yylval, lex);
 
@@ -370,7 +370,7 @@ static int parse_ipv4_address(FASTD_CONFIG_STYPE *yylval, FASTD_CONFIG_LTYPE *yy
 }
 
 /** Tries to process the current input as a number */
-static int parse_number(FASTD_CONFIG_STYPE *yylval, FASTD_CONFIG_LTYPE *yylloc, fastd_lex_t *lex) {
+static int parse_number(FASTD_CONFIG_STYPE * const yylval, FASTD_CONFIG_LTYPE * const yylloc, fastd_lex_t * const lex) {
 	bool digitonly = true;
 
 	if (lex->needspace)
@@ -405,7 +405,7 @@ static int parse_number(FASTD_CONFIG_STYPE *yylval, FASTD_CONFIG_LTYPE *yylloc, 
 }
 
 /** Tries to process the current input as a keyword */
-static int parse_keyword(FASTD_CONFIG_STYPE *yylval, FASTD_CONFIG_LTYPE *yylloc, fastd_lex_t *lex) {
+static int parse_keyword(FASTD_CONFIG_STYPE * const yylval, FASTD_CONFIG_LTYPE * const yylloc, fastd_lex_t * const lex) {
 	if (lex->needspace)
 		return syntax_error(yylval, lex);
 
@@ -431,7 +431,7 @@ static int parse_keyword(FASTD_CONFIG_STYPE *yylval, FASTD_CONFIG_LTYPE *yylloc,
 
 
 /** Initializes a new scanner for the given file */
-fastd_lex_t *fastd_lex_init(FILE *file) {
+fastd_lex_t *fastd_lex_init(FILE * const file) {
 	fastd_lex_t *lex = fastd_new0(fastd_lex_t);
 	lex->file = file;
 
@@ -441,12 +441,12 @@ fastd_lex_t *fastd_lex_init(FILE *file) {
 }
 
 /** Destroys the scanner */
-void fastd_lex_destroy(fastd_lex_t *lex) {
+void fastd_lex_destroy(fastd_lex_t * const lex) {
 	free(lex);
 }
 
 /** Returns a single lexeme of the scanned file */
-int fastd_lex(FASTD_CONFIG_STYPE *yylval, FASTD_CONFIG_LTYPE *yylloc, fastd_lex_t *lex) {
+int fastd_lex(FASTD_CONFIG_STYPE * const yylval, FASTD_CONFIG_LTYPE * const yylloc, fastd_lex_t * const lex) {
 	int token;
 
 	while (lex->end > lex->start) {

--- a/src/lex.h
+++ b/src/lex.h
@@ -19,7 +19,7 @@
 #include <stdio.h>
 
 
-fastd_lex_t *fastd_lex_init(FILE *file);
-void fastd_lex_destroy(fastd_lex_t *lex);
+fastd_lex_t *fastd_lex_init(FILE * const file);
+void fastd_lex_destroy(fastd_lex_t * const lex);
 
-int fastd_lex(FASTD_CONFIG_STYPE *yylval, FASTD_CONFIG_LTYPE *yylloc, fastd_lex_t *lex);
+int fastd_lex(FASTD_CONFIG_STYPE * const yylval, FASTD_CONFIG_LTYPE * const yylloc, fastd_lex_t * const lex);

--- a/src/peer.c
+++ b/src/peer.c
@@ -22,7 +22,7 @@
 
 /** Adds address and port of an fastd_peer_address_t to \e env */
 static void fastd_peer_set_shell_env_addr(
-	fastd_shell_env_t *env, const fastd_peer_address_t *addr, const char *address_var, const char *port_var) {
+	fastd_shell_env_t * const env, const fastd_peer_address_t * const addr, const char * const address_var, const char * const port_var) {
 	/* both INET6_ADDRSTRLEN and IFNAMSIZ already include space for the zero termination, so there is no need to add
 	 * space for the '%' here. */
 	char buf[INET6_ADDRSTRLEN + IFNAMSIZ];
@@ -60,7 +60,7 @@ static void fastd_peer_set_shell_env_addr(
 
 /** Adds peer-specific fields to \e env */
 void fastd_peer_set_shell_env(
-	fastd_shell_env_t *env, const fastd_peer_t *peer, const fastd_peer_address_t *local_addr,
+	fastd_shell_env_t * const env, const fastd_peer_t * const peer, const fastd_peer_address_t * const local_addr,
 	const fastd_peer_address_t *peer_addr) {
 
 	fastd_shell_env_set(env, "PEER_NAME", peer ? peer->name : NULL);
@@ -75,8 +75,8 @@ void fastd_peer_set_shell_env(
 
 /** Executes a shell command, providing peer-specific enviroment fields */
 void fastd_peer_exec_shell_command(
-	const fastd_shell_command_t *command, const fastd_peer_t *peer, const fastd_peer_address_t *local_addr,
-	const fastd_peer_address_t *peer_addr, bool sync) {
+	const fastd_shell_command_t * const command, const fastd_peer_t * const peer, const fastd_peer_address_t * const local_addr,
+	const fastd_peer_address_t * const peer_addr, const bool sync) {
 	fastd_shell_env_t *env = fastd_shell_env_alloc();
 	fastd_peer_set_shell_env(env, peer, local_addr, peer_addr);
 
@@ -89,32 +89,32 @@ void fastd_peer_exec_shell_command(
 }
 
 /** Calls the on-up command */
-static inline void on_up(const fastd_peer_t *peer, bool sync) {
+static inline void on_up(const fastd_peer_t * const peer, const bool sync) {
 	const fastd_shell_command_t *on_up = fastd_peer_group_lookup_peer_shell_command(peer, on_up);
 	fastd_peer_exec_shell_command(on_up, peer, NULL, NULL, sync);
 }
 
 /** Calls the on-down command */
-static inline void on_down(const fastd_peer_t *peer, bool sync) {
+static inline void on_down(const fastd_peer_t * const peer, const bool sync) {
 	const fastd_shell_command_t *on_down = fastd_peer_group_lookup_peer_shell_command(peer, on_down);
 	fastd_peer_exec_shell_command(on_down, peer, NULL, NULL, sync);
 }
 
 /** Executes the on-establish command for a peer */
-static inline void on_establish(const fastd_peer_t *peer) {
-	const fastd_shell_command_t *on_establish = fastd_peer_group_lookup_peer_shell_command(peer, on_establish);
+static inline void on_establish(const fastd_peer_t * const peer) {
+	const fastd_shell_command_t * const on_establish = fastd_peer_group_lookup_peer_shell_command(peer, on_establish);
 	fastd_peer_exec_shell_command(on_establish, peer, &peer->local_address, &peer->address, false);
 }
 
 /** Executes the on-disestablish command for a peer */
-static inline void on_disestablish(const fastd_peer_t *peer) {
-	const fastd_shell_command_t *on_disestablish =
+static inline void on_disestablish(const fastd_peer_t * const peer) {
+	const fastd_shell_command_t * const on_disestablish =
 		fastd_peer_group_lookup_peer_shell_command(peer, on_disestablish);
 	fastd_peer_exec_shell_command(on_disestablish, peer, &peer->local_address, &peer->address, false);
 }
 
 /** Compares two peers by their peer ID */
-static int peer_id_cmp(fastd_peer_t *const *a, fastd_peer_t *const *b) {
+static int peer_id_cmp(fastd_peer_t *const *const a, fastd_peer_t *const *const b) {
 	if ((*a)->id == (*b)->id)
 		return 0;
 	else if ((*a)->id < (*b)->id)
@@ -124,7 +124,7 @@ static int peer_id_cmp(fastd_peer_t *const *a, fastd_peer_t *const *b) {
 }
 
 /** Finds the entry for a peer with a specified ID in the array \e ctx.peers */
-static fastd_peer_t **peer_p_find_by_id(uint64_t id) {
+static fastd_peer_t **peer_p_find_by_id(const uint64_t id) {
 	fastd_peer_t key = { .id = id };
 	fastd_peer_t *const keyp = &key;
 
@@ -132,7 +132,7 @@ static fastd_peer_t **peer_p_find_by_id(uint64_t id) {
 }
 
 /** Finds the index of a peer with a specified ID in the array \e ctx.peers */
-static size_t peer_index_find_by_id(uint64_t id) {
+static size_t peer_index_find_by_id(const uint64_t id) {
 	fastd_peer_t **ret = peer_p_find_by_id(id);
 
 	if (!ret)
@@ -142,12 +142,12 @@ static size_t peer_index_find_by_id(uint64_t id) {
 }
 
 /** Finds the index of a peer in the array \e ctx.peers */
-static inline size_t peer_index(fastd_peer_t *peer) {
+static inline size_t peer_index(const fastd_peer_t *const peer) {
 	return peer_index_find_by_id(peer->id);
 }
 
 /** Finds a peer with a specified ID */
-fastd_peer_t *fastd_peer_find_by_id(uint64_t id) {
+fastd_peer_t *fastd_peer_find_by_id(const uint64_t id) {
 	fastd_peer_t **ret = peer_p_find_by_id(id);
 
 	if (ret)
@@ -157,7 +157,7 @@ fastd_peer_t *fastd_peer_find_by_id(uint64_t id) {
 }
 
 /** Closes and frees a peer's dynamic socket */
-static inline void free_socket(fastd_peer_t *peer) {
+static inline void free_socket(fastd_peer_t * const peer) {
 	if (!peer->sock)
 		return;
 
@@ -173,9 +173,9 @@ static inline void free_socket(fastd_peer_t *peer) {
 }
 
 /** Checks if a peer group has any contraints which might cause connection attempts to be rejected */
-static inline bool has_group_config_constraints(const fastd_peer_group_t *group) {
-	for (; group; group = group->parent) {
-		if (group->max_connections >= 0)
+static inline bool has_group_config_constraints(const fastd_peer_group_t * const group) {
+	for (const fastd_peer_group_t *group_iterator=group; group_iterator; group_iterator = group_iterator->parent) {
+		if (group_iterator->max_connections >= 0)
 			return true;
 	}
 
@@ -188,7 +188,7 @@ static inline bool has_group_config_constraints(const fastd_peer_group_t *group)
    If the peer's old socket is dynamic, it is closed. Then either a new dynamic socket is opened
    or a default socket is used.
 */
-void fastd_peer_reset_socket(fastd_peer_t *peer) {
+void fastd_peer_reset_socket(fastd_peer_t * const peer) {
 	if (peer->address.sa.sa_family == AF_UNSPEC) {
 		free_socket(peer);
 		return;
@@ -218,7 +218,7 @@ void fastd_peer_reset_socket(fastd_peer_t *peer) {
 }
 
 /** Schedules the peer maintenance task (or removes the scheduled task if there's nothing to do) */
-static void schedule_peer_task(fastd_peer_t *peer) {
+static void schedule_peer_task(fastd_peer_t * const peer) {
 	fastd_timeout_t timeout = fastd_timeout_min(
 		peer->reset_timeout, fastd_timeout_min(peer->keepalive_timeout, peer->next_handshake));
 
@@ -235,12 +235,12 @@ static void schedule_peer_task(fastd_peer_t *peer) {
 }
 
 /** Sets the timeout for the next handshake without actually rescheduling */
-static void set_next_handshake(fastd_peer_t *peer, int delay) {
+static void set_next_handshake(fastd_peer_t * const peer, const int delay) {
 	peer->next_handshake = ctx.now + delay;
 }
 
 /** Sets the timeout for the next handshake to the default delay and jitter without actually rescheduling */
-static void set_next_handshake_default(fastd_peer_t *peer) {
+static void set_next_handshake_default(fastd_peer_t * const peer) {
 	set_next_handshake(peer, fastd_peer_handshake_default_rand());
 }
 
@@ -250,25 +250,26 @@ static void set_next_handshake_default(fastd_peer_t *peer) {
    @param peer	the peer
    @param delay	the delay in milliseconds
 */
-void fastd_peer_schedule_handshake(fastd_peer_t *peer, int delay) {
+void fastd_peer_schedule_handshake(fastd_peer_t * const peer, const int delay) {
 	set_next_handshake(peer, delay);
 	schedule_peer_task(peer);
 }
 
 /** Checks if the peer group \e group1 lies in \e group2 */
-static inline bool is_group_in(const fastd_peer_group_t *group1, const fastd_peer_group_t *group2) {
-	while (group1) {
-		if (group1 == group2)
+static inline bool is_group_in(const fastd_peer_group_t * const group1, const fastd_peer_group_t * const group2) {
+	for (const fastd_peer_group_t * group_iterator=group1;
+	     group_iterator;
+	     group_iterator = group_iterator->parent) {
+		if (group_iterator == group2) {
 			return true;
-
-		group1 = group1->parent;
+		}
 	}
 
 	return false;
 }
 
 /** Checks if a peer lies in a peer group */
-static bool is_peer_in_group(const fastd_peer_t *peer, const fastd_peer_group_t *group) {
+static bool is_peer_in_group(const fastd_peer_t * const peer, const fastd_peer_group_t * const group) {
 	return is_group_in(peer->group, group);
 }
 
@@ -279,7 +280,7 @@ static bool is_peer_in_group(const fastd_peer_t *peer, const fastd_peer_group_t 
 
    After a call to reset_peer a peer must be deleted by delete_peer or re-initialized by setup_peer.
 */
-static void reset_peer(fastd_peer_t *peer) {
+static void reset_peer(fastd_peer_t * const peer) {
 	if (fastd_peer_is_established(peer)) {
 		on_disestablish(peer);
 		pr_info("connection with %P disestablished.", peer);
@@ -327,7 +328,7 @@ static void reset_peer(fastd_peer_t *peer) {
    make the choice of peers random (it will be biased by the latency, which might or might not be
    what a user wants)
 */
-static void init_handshake(fastd_peer_t *peer) {
+static void init_handshake(fastd_peer_t * const peer) {
 	unsigned delay = 0;
 	if (has_group_config_constraints(peer->group))
 		delay = fastd_rand(0, 3000);
@@ -339,7 +340,7 @@ static void init_handshake(fastd_peer_t *peer) {
 
 /** Handles an asynchronous DNS resolve response */
 void fastd_peer_handle_resolve(
-	fastd_peer_t *peer, fastd_remote_t *remote, size_t n_addresses, const fastd_peer_address_t *addresses) {
+	fastd_peer_t * const peer, fastd_remote_t * const remote, const size_t n_addresses, const fastd_peer_address_t * const addresses) {
 	free(remote->addresses);
 	remote->addresses = fastd_new_array(n_addresses, fastd_peer_address_t);
 	memcpy(remote->addresses, addresses, n_addresses * sizeof(fastd_peer_address_t));
@@ -352,7 +353,7 @@ void fastd_peer_handle_resolve(
 }
 
 /** Initializes a peer */
-static void setup_peer(fastd_peer_t *peer) {
+static void setup_peer(fastd_peer_t * const peer) {
 	if (VECTOR_LEN(peer->remotes) == 0) {
 		peer->next_remote = -1;
 	} else {
@@ -431,7 +432,7 @@ static void setup_peer(fastd_peer_t *peer) {
    If the peer has already been added to the peer list,
    use fastd_peer_delete() instead.
 */
-void fastd_peer_free(fastd_peer_t *peer) {
+void fastd_peer_free(fastd_peer_t * const peer) {
 	free(peer->key);
 
 	size_t i;
@@ -452,7 +453,7 @@ void fastd_peer_free(fastd_peer_t *peer) {
 }
 
 /** Deletes a peer */
-static void delete_peer(fastd_peer_t *peer) {
+static void delete_peer(fastd_peer_t * const peer) {
 	if (fastd_peer_is_dynamic(peer) || peer->config_source_dir)
 		pr_verbose("deleting peer %P", peer);
 
@@ -471,7 +472,7 @@ static void delete_peer(fastd_peer_t *peer) {
 
 
 /** Checks if two fastd_peer_address_t are equal */
-bool fastd_peer_address_equal(const fastd_peer_address_t *addr1, const fastd_peer_address_t *addr2) {
+bool fastd_peer_address_equal(const fastd_peer_address_t * const addr1, const fastd_peer_address_t * const addr2) {
 	if (addr1->sa.sa_family != addr2->sa.sa_family)
 		return false;
 
@@ -501,7 +502,7 @@ bool fastd_peer_address_equal(const fastd_peer_address_t *addr1, const fastd_pee
 }
 
 /** If \e addr is a v4-mapped IPv6 address, it is converted to an IPv4 address */
-void fastd_peer_address_simplify(fastd_peer_address_t *addr) {
+void fastd_peer_address_simplify(fastd_peer_address_t * const addr) {
 	if (addr->sa.sa_family == AF_INET6 && IN6_IS_ADDR_V4MAPPED(&addr->in6.sin6_addr)) {
 		struct sockaddr_in6 mapped = addr->in6;
 
@@ -513,7 +514,7 @@ void fastd_peer_address_simplify(fastd_peer_address_t *addr) {
 }
 
 /** If \e addr is an IPv4 address, it is converted to a v4-mapped IPv6 address */
-void fastd_peer_address_widen(fastd_peer_address_t *addr) {
+void fastd_peer_address_widen(fastd_peer_address_t * const addr) {
 	if (addr->sa.sa_family == AF_INET) {
 		struct sockaddr_in addr4 = addr->in;
 
@@ -528,7 +529,7 @@ void fastd_peer_address_widen(fastd_peer_address_t *addr) {
 
 
 /** Resets a peer's address to the unspecified address */
-static inline void reset_peer_address(fastd_peer_t *peer) {
+static inline void reset_peer_address(fastd_peer_t * const peer) {
 	if (fastd_peer_is_established(peer)) {
 		fastd_peer_reset(peer);
 	} else {
@@ -538,7 +539,7 @@ static inline void reset_peer_address(fastd_peer_t *peer) {
 }
 
 /** Checks if an address is statically configured for a peer */
-bool fastd_peer_owns_address(const fastd_peer_t *peer, const fastd_peer_address_t *addr) {
+bool fastd_peer_owns_address(const fastd_peer_t * const peer, const fastd_peer_address_t * const addr) {
 	if (fastd_peer_is_floating(peer))
 		return false;
 
@@ -557,7 +558,7 @@ bool fastd_peer_owns_address(const fastd_peer_t *peer, const fastd_peer_address_
 }
 
 /** Checks if an address matches any of the configured or resolved remotes of a peer */
-bool fastd_peer_matches_address(const fastd_peer_t *peer, const fastd_peer_address_t *addr) {
+bool fastd_peer_matches_address(const fastd_peer_t * const peer, const fastd_peer_address_t * const addr) {
 	if (fastd_peer_is_floating(peer))
 		return true;
 
@@ -584,8 +585,8 @@ bool fastd_peer_matches_address(const fastd_peer_t *peer, const fastd_peer_addre
    in question.
  */
 bool fastd_peer_claim_address(
-	fastd_peer_t *new_peer, fastd_socket_t *sock, const fastd_peer_address_t *local_addr,
-	const fastd_peer_address_t *remote_addr, bool force) {
+	fastd_peer_t * const new_peer, fastd_socket_t * const sock, const fastd_peer_address_t * const local_addr,
+	const fastd_peer_address_t * const remote_addr, const bool force) {
 	if (remote_addr->sa.sa_family == AF_UNSPEC) {
 		if (fastd_peer_is_established(new_peer))
 			fastd_peer_reset(new_peer);
@@ -633,7 +634,7 @@ bool fastd_peer_claim_address(
 }
 
 /** Resets and re-initializes a peer */
-void fastd_peer_reset(fastd_peer_t *peer) {
+void fastd_peer_reset(fastd_peer_t * const peer) {
 	if (peer->state != STATE_INACTIVE) {
 		pr_debug("resetting peer %P", peer);
 		reset_peer(peer);
@@ -643,13 +644,13 @@ void fastd_peer_reset(fastd_peer_t *peer) {
 }
 
 /** Deletes a peer */
-void fastd_peer_delete(fastd_peer_t *peer) {
+void fastd_peer_delete(fastd_peer_t * const peer) {
 	reset_peer(peer);
 	delete_peer(peer);
 }
 
 /** Counts how many peers in the given peer group have established a connection */
-static inline size_t count_established_group_peers(const fastd_peer_group_t *group) {
+static inline size_t count_established_group_peers(const fastd_peer_group_t * const group) {
 	size_t i, ret = 0;
 	for (i = 0; i < VECTOR_LEN(ctx.peers); i++) {
 		fastd_peer_t *peer = VECTOR_INDEX(ctx.peers, i);
@@ -662,7 +663,7 @@ static inline size_t count_established_group_peers(const fastd_peer_group_t *gro
 }
 
 /** Checks if a peer may currently establish a connection */
-bool fastd_peer_may_connect(fastd_peer_t *peer) {
+bool fastd_peer_may_connect(fastd_peer_t * const peer) {
 	if (fastd_peer_is_established(peer))
 		return true;
 
@@ -680,7 +681,7 @@ bool fastd_peer_may_connect(fastd_peer_t *peer) {
 }
 
 /** Checks if two peer configurations are equivalent (exept for the name) */
-static inline bool peer_configs_equal(const fastd_peer_t *peer1, const fastd_peer_t *peer2) {
+static inline bool peer_configs_equal(const fastd_peer_t * const peer1, const fastd_peer_t * const peer2) {
 	if (peer1->group != peer2->group)
 		return false;
 
@@ -709,7 +710,7 @@ static inline bool peer_configs_equal(const fastd_peer_t *peer1, const fastd_pee
 }
 
 /** Adds a new peer */
-bool fastd_peer_add(fastd_peer_t *peer) {
+bool fastd_peer_add(fastd_peer_t * const peer) {
 	if (!peer->key) {
 		pr_warn("no valid key configured for peer %P", peer);
 		goto error;
@@ -774,12 +775,12 @@ error:
 }
 
 /** Prints a debug message when no handshake could be sent because the current remote didn't resolve successfully */
-static inline void no_valid_address_debug(const fastd_peer_t *peer) {
+static inline void no_valid_address_debug(const fastd_peer_t * const peer) {
 	pr_debug("not sending a handshake to %P (no valid address resolved)", peer);
 }
 
 /** Sends a new handshake to the current address of the given remote of a peer */
-static void send_handshake(fastd_peer_t *peer, fastd_remote_t *next_remote) {
+static void send_handshake(fastd_peer_t *peer, fastd_remote_t * const next_remote) {
 	if (!fastd_peer_is_established(peer)) {
 		if (!next_remote->n_addresses) {
 			no_valid_address_debug(peer);
@@ -811,7 +812,7 @@ static void send_handshake(fastd_peer_t *peer, fastd_remote_t *next_remote) {
 }
 
 /** Marks a peer as established */
-bool fastd_peer_set_established(fastd_peer_t *peer) {
+bool fastd_peer_set_established(fastd_peer_t * const peer) {
 	if (fastd_peer_is_established(peer))
 		return true;
 
@@ -837,18 +838,18 @@ bool fastd_peer_set_established(fastd_peer_t *peer) {
 }
 
 /** Compares two MAC addresses */
-static inline int eth_addr_cmp(const fastd_eth_addr_t *addr1, const fastd_eth_addr_t *addr2) {
+static inline int eth_addr_cmp(const fastd_eth_addr_t * const addr1, const fastd_eth_addr_t * const addr2) {
 	return memcmp(addr1->data, addr2->data, sizeof(fastd_eth_addr_t));
 }
 
 /** Compares two fastd_peer_eth_addr_t entries by their MAC addresses */
-static int peer_eth_addr_cmp(const fastd_peer_eth_addr_t *addr1, const fastd_peer_eth_addr_t *addr2) {
+static int peer_eth_addr_cmp(const fastd_peer_eth_addr_t * const addr1, const fastd_peer_eth_addr_t * const addr2) {
 	return eth_addr_cmp(&addr1->addr, &addr2->addr);
 }
 
 /** Adds a MAC address to the sorted list of addresses associated with a peer (or updates the timeout of an existing
  * entry) */
-void fastd_peer_eth_addr_add(fastd_peer_t *peer, fastd_eth_addr_t addr) {
+void fastd_peer_eth_addr_add(fastd_peer_t * const peer, const fastd_eth_addr_t addr) {
 	size_t min = 0, max = VECTOR_LEN(ctx.eth_addrs);
 
 	if (peer && !fastd_peer_is_established(peer))
@@ -878,7 +879,7 @@ void fastd_peer_eth_addr_add(fastd_peer_t *peer, fastd_eth_addr_t addr) {
 }
 
 /** Finds the peer that is associated with a given MAC address */
-bool fastd_peer_find_by_eth_addr(const fastd_eth_addr_t addr, fastd_peer_t **peer) {
+bool fastd_peer_find_by_eth_addr(const fastd_eth_addr_t addr, fastd_peer_t ** const peer) {
 	const fastd_peer_eth_addr_t key = { .addr = addr };
 	fastd_peer_eth_addr_t *peer_eth_addr = VECTOR_BSEARCH(&key, ctx.eth_addrs, peer_eth_addr_cmp);
 
@@ -890,7 +891,7 @@ bool fastd_peer_find_by_eth_addr(const fastd_eth_addr_t addr, fastd_peer_t **pee
 }
 
 /** Sends a handshake to one peer, if a scheduled handshake is due */
-static void handle_task_handshake(fastd_peer_t *peer) {
+static void handle_task_handshake(fastd_peer_t * const peer) {
 	set_next_handshake_default(peer);
 
 	if (!fastd_peer_may_connect(peer)) {
@@ -934,8 +935,8 @@ static void handle_task_handshake(fastd_peer_t *peer) {
    \li If no data was received from the peer for some time, it is reset.
    \li If no data was sent to the peer for some time, a keepalive is sent.
  */
-void fastd_peer_handle_task(fastd_task_t *task) {
-	fastd_peer_t *peer = container_of(task, fastd_peer_t, task);
+void fastd_peer_handle_task(fastd_task_t * const task) {
+	fastd_peer_t * const peer = container_of(task, fastd_peer_t, task);
 
 	/* check for peer timeout */
 	if (fastd_timed_out(peer->reset_timeout)) {

--- a/src/peer.h
+++ b/src/peer.h
@@ -116,44 +116,44 @@ struct fastd_remote {
 };
 
 
-bool fastd_peer_address_equal(const fastd_peer_address_t *addr1, const fastd_peer_address_t *addr2);
-void fastd_peer_address_simplify(fastd_peer_address_t *addr);
-void fastd_peer_address_widen(fastd_peer_address_t *addr);
+bool fastd_peer_address_equal(const fastd_peer_address_t * const addr1, const fastd_peer_address_t * const addr2);
+void fastd_peer_address_simplify(fastd_peer_address_t * const addr);
+void fastd_peer_address_widen(fastd_peer_address_t * const addr);
 
-bool fastd_peer_add(fastd_peer_t *peer);
-void fastd_peer_reset(fastd_peer_t *peer);
-void fastd_peer_delete(fastd_peer_t *peer);
-void fastd_peer_free(fastd_peer_t *peer);
-bool fastd_peer_set_established(fastd_peer_t *peer);
-bool fastd_peer_may_connect(fastd_peer_t *peer);
+bool fastd_peer_add(fastd_peer_t * const peer);
+void fastd_peer_reset(fastd_peer_t * const peer);
+void fastd_peer_delete(fastd_peer_t * const peer);
+void fastd_peer_free(fastd_peer_t * const peer);
+bool fastd_peer_set_established(fastd_peer_t * const peer);
+bool fastd_peer_may_connect(fastd_peer_t * const peer);
 void fastd_peer_handle_resolve(
-	fastd_peer_t *peer, fastd_remote_t *remote, size_t n_addresses, const fastd_peer_address_t *addresses);
-bool fastd_peer_owns_address(const fastd_peer_t *peer, const fastd_peer_address_t *addr);
-bool fastd_peer_matches_address(const fastd_peer_t *peer, const fastd_peer_address_t *addr);
+	fastd_peer_t * const peer, fastd_remote_t * const remote, const size_t n_addresses, const fastd_peer_address_t * const addresses);
+bool fastd_peer_owns_address(const fastd_peer_t * const peer, const fastd_peer_address_t * const addr);
+bool fastd_peer_matches_address(const fastd_peer_t *peer, const fastd_peer_address_t * const addr);
 bool fastd_peer_claim_address(
-	fastd_peer_t *peer, fastd_socket_t *sock, const fastd_peer_address_t *local_addr,
-	const fastd_peer_address_t *remote_addr, bool force);
-void fastd_peer_reset_socket(fastd_peer_t *peer);
-void fastd_peer_schedule_handshake(fastd_peer_t *peer, int delay);
-fastd_peer_t *fastd_peer_find_by_id(uint64_t id);
+	fastd_peer_t * const peer, fastd_socket_t * const sock, const fastd_peer_address_t * const local_addr,
+	const fastd_peer_address_t * const remote_addr, const bool force);
+void fastd_peer_reset_socket(fastd_peer_t * const peer);
+void fastd_peer_schedule_handshake(fastd_peer_t * const peer, const int delay);
+fastd_peer_t *fastd_peer_find_by_id(const uint64_t id);
 
 void fastd_peer_set_shell_env(
-	fastd_shell_env_t *env, const fastd_peer_t *peer, const fastd_peer_address_t *local_addr,
-	const fastd_peer_address_t *peer_addr);
+	fastd_shell_env_t * const env, const fastd_peer_t * const peer, const fastd_peer_address_t * const local_addr,
+	const fastd_peer_address_t * const peer_addr);
 void fastd_peer_exec_shell_command(
-	const fastd_shell_command_t *command, const fastd_peer_t *peer, const fastd_peer_address_t *local_addr,
-	const fastd_peer_address_t *peer_addr, bool sync);
+	const fastd_shell_command_t * const command, const fastd_peer_t * const peer, const fastd_peer_address_t * const local_addr,
+	const fastd_peer_address_t * const peer_addr, const bool sync);
 
-void fastd_peer_eth_addr_add(fastd_peer_t *peer, fastd_eth_addr_t addr);
-bool fastd_peer_find_by_eth_addr(const fastd_eth_addr_t addr, fastd_peer_t **peer);
+void fastd_peer_eth_addr_add(fastd_peer_t * const peer, const fastd_eth_addr_t addr);
+bool fastd_peer_find_by_eth_addr(const fastd_eth_addr_t addr, fastd_peer_t ** const peer);
 
-void fastd_peer_handle_task(fastd_task_t *task);
+void fastd_peer_handle_task(fastd_task_t * const task);
 void fastd_peer_eth_addr_cleanup(void);
 void fastd_peer_reset_all(void);
 
 
 /** Returns the port of a fastd_peer_address_t (in network byte order) */
-static inline uint16_t fastd_peer_address_get_port(const fastd_peer_address_t *addr) {
+static inline uint16_t fastd_peer_address_get_port(const fastd_peer_address_t * const addr) {
 	switch (addr->sa.sa_family) {
 	case AF_INET:
 		return addr->in.sin_port;
@@ -174,25 +174,25 @@ static inline int fastd_peer_handshake_default_rand(void) {
 }
 
 /** Schedules a handshake with the default delay and jitter */
-static inline void fastd_peer_schedule_handshake_default(fastd_peer_t *peer) {
+static inline void fastd_peer_schedule_handshake_default(fastd_peer_t * const peer) {
 	fastd_peer_schedule_handshake(peer, fastd_peer_handshake_default_rand());
 }
 
 /** Cancels a scheduled handshake */
-static inline void fastd_peer_unschedule_handshake(fastd_peer_t *peer) {
+static inline void fastd_peer_unschedule_handshake(fastd_peer_t * const peer) {
 	peer->next_handshake = FASTD_TIMEOUT_INV;
 }
 
 #ifdef WITH_DYNAMIC_PEERS
 /** Call to signal that there is currently an asychronous on-verify command running for the peer */
-static inline void fastd_peer_set_verifying(fastd_peer_t *peer) {
+static inline void fastd_peer_set_verifying(fastd_peer_t * const peer) {
 	peer->verify_timeout = ctx.now + MIN_VERIFY_INTERVAL;
 
 	fastd_timeout_advance(&peer->reset_timeout, peer->verify_timeout);
 }
 
 /** Marks the peer verification as successful or failed */
-static inline void fastd_peer_set_verified(fastd_peer_t *peer, bool ok) {
+static inline void fastd_peer_set_verified(fastd_peer_t * const peer, const bool ok) {
 	peer->verify_valid_timeout = ctx.now + (ok ? VERIFY_VALID_TIME : 0);
 
 	fastd_timeout_advance(&peer->reset_timeout, peer->verify_valid_timeout);
@@ -200,17 +200,17 @@ static inline void fastd_peer_set_verified(fastd_peer_t *peer, bool ok) {
 #endif
 
 /** Checks if there's a handshake queued for the peer */
-static inline bool fastd_peer_handshake_scheduled(fastd_peer_t *peer) {
+static inline bool fastd_peer_handshake_scheduled(fastd_peer_t * const peer) {
 	return (peer->next_handshake != FASTD_TIMEOUT_INV);
 }
 
 /** Checks if a peer is floating (is has at least one floating remote or no remotes at all) */
-static inline bool fastd_peer_is_floating(const fastd_peer_t *peer) {
+static inline bool fastd_peer_is_floating(const fastd_peer_t * const peer) {
 	return (!VECTOR_LEN(peer->remotes) || peer->floating);
 }
 
 /** Checks if a peer is not statically configured, but added after a on-verify run */
-static inline bool fastd_peer_is_dynamic(UNUSED const fastd_peer_t *peer) {
+static inline bool fastd_peer_is_dynamic(UNUSED const fastd_peer_t * const peer) {
 #ifdef WITH_DYNAMIC_PEERS
 	return peer->config_state == CONFIG_DYNAMIC;
 #else
@@ -219,7 +219,7 @@ static inline bool fastd_peer_is_dynamic(UNUSED const fastd_peer_t *peer) {
 }
 
 /** Checks if a peer is enabled */
-static inline bool fastd_peer_is_enabled(const fastd_peer_t *peer) {
+static inline bool fastd_peer_is_enabled(const fastd_peer_t * const peer) {
 	switch (peer->config_state) {
 	case CONFIG_STATIC:
 #ifdef WITH_DYNAMIC_PEERS
@@ -232,7 +232,7 @@ static inline bool fastd_peer_is_enabled(const fastd_peer_t *peer) {
 }
 
 /** Returns the currently active remote entry */
-static inline fastd_remote_t *fastd_peer_get_next_remote(fastd_peer_t *peer) {
+static inline fastd_remote_t *fastd_peer_get_next_remote(fastd_peer_t * const peer) {
 	if (peer->next_remote < 0)
 		return NULL;
 
@@ -240,7 +240,7 @@ static inline fastd_remote_t *fastd_peer_get_next_remote(fastd_peer_t *peer) {
 }
 
 /** Checks if the peer currently has an established connection */
-static inline bool fastd_peer_is_established(const fastd_peer_t *peer) {
+static inline bool fastd_peer_is_established(const fastd_peer_t * const peer) {
 	switch (peer->state) {
 	case STATE_ESTABLISHED:
 		return true;
@@ -251,22 +251,22 @@ static inline bool fastd_peer_is_established(const fastd_peer_t *peer) {
 }
 
 /** Signals that a valid packet was received from the peer */
-static inline void fastd_peer_seen(fastd_peer_t *peer) {
+static inline void fastd_peer_seen(fastd_peer_t * const peer) {
 	peer->reset_timeout = ctx.now + PEER_STALE_TIME;
 }
 
 /** Resets the keepalive timeout */
-static inline void fastd_peer_clear_keepalive(fastd_peer_t *peer) {
+static inline void fastd_peer_clear_keepalive(fastd_peer_t * const peer) {
 	peer->keepalive_timeout = ctx.now + KEEPALIVE_TIMEOUT;
 }
 
 /** Checks if a peer uses dynamic sockets (which means that each connection attempt uses a new socket) */
-static inline bool fastd_peer_is_socket_dynamic(const fastd_peer_t *peer) {
+static inline bool fastd_peer_is_socket_dynamic(const fastd_peer_t * const peer) {
 	return (!peer->sock || !peer->sock->addr);
 }
 
 /** Returns the MTU to use for a peer */
-static inline uint16_t fastd_peer_get_mtu(const fastd_peer_t *peer) {
+static inline uint16_t fastd_peer_get_mtu(const fastd_peer_t * const peer) {
 	if (conf.mode == MODE_TAP)
 		return conf.mtu;
 
@@ -277,12 +277,12 @@ static inline uint16_t fastd_peer_get_mtu(const fastd_peer_t *peer) {
 }
 
 /** Checks if a MAC address is a normal unicast address */
-static inline bool fastd_eth_addr_is_unicast(fastd_eth_addr_t addr) {
+static inline bool fastd_eth_addr_is_unicast(const fastd_eth_addr_t addr) { // FIXME: this should not be passed by value
 	return ((addr.data[0] & 1) == 0);
 }
 
 /** Adds statistics for a single packet of a given size */
-static inline void fastd_stats_add(UNUSED fastd_peer_t *peer, UNUSED fastd_stat_type_t stat, UNUSED size_t bytes) {
+static inline void fastd_stats_add(UNUSED fastd_peer_t * const peer, UNUSED fastd_stat_type_t stat, UNUSED size_t bytes) {
 #ifdef WITH_STATUS_SOCKET
 	if (!bytes)
 		return;

--- a/src/polling.c
+++ b/src/polling.c
@@ -47,7 +47,7 @@ static inline int task_timeout(void) {
 
 
 /** Handles a file descriptor that was selected on */
-static inline void handle_fd(fastd_poll_fd_t *fd, bool input, bool error) {
+static inline void handle_fd(fastd_poll_fd_t * const fd, const bool input, const bool error) {
 	switch (fd->type) {
 	case POLL_TYPE_ASYNC:
 		if (input)
@@ -103,7 +103,7 @@ static inline void handle_fd(fastd_poll_fd_t *fd, bool input, bool error) {
 #endif
 
 /** Simplified epoll_pwait wrapper (as there are systems without or with broken epoll_pwait) */
-static inline int epoll_wait_unblocked(int epfd, struct epoll_event *events, int maxevents, int timeout) {
+static inline int epoll_wait_unblocked(const int epfd, struct epoll_event * const events, const int maxevents, const int timeout) {
 	const uint8_t buf[_NSIG / 8] = {};
 	return syscall(SYS_epoll_pwait, epfd, events, maxevents, timeout, buf, sizeof(buf));
 }
@@ -121,7 +121,7 @@ void fastd_poll_free(void) {
 }
 
 
-void fastd_poll_fd_register(fastd_poll_fd_t *fd) {
+void fastd_poll_fd_register(fastd_poll_fd_t * const fd) {
 	if (fd->fd < 0)
 		exit_bug("fastd_poll_fd_register: invalid FD");
 
@@ -134,7 +134,7 @@ void fastd_poll_fd_register(fastd_poll_fd_t *fd) {
 		exit_errno("epoll_ctl");
 }
 
-bool fastd_poll_fd_close(fastd_poll_fd_t *fd) {
+bool fastd_poll_fd_close(fastd_poll_fd_t * const fd) {
 	if (epoll_ctl(ctx.epoll_fd, EPOLL_CTL_DEL, fd->fd, NULL) < 0)
 		exit_errno("epoll_ctl");
 
@@ -170,7 +170,7 @@ void fastd_poll_free(void) {
 }
 
 
-void fastd_poll_fd_register(fastd_poll_fd_t *fd) {
+void fastd_poll_fd_register(fastd_poll_fd_t * const fd) {
 	if (fd->fd < 0)
 		exit_bug("fastd_poll_fd_register: invalid FD");
 
@@ -182,7 +182,7 @@ void fastd_poll_fd_register(fastd_poll_fd_t *fd) {
 	VECTOR_RESIZE(ctx.pollfds, 0);
 }
 
-bool fastd_poll_fd_close(fastd_poll_fd_t *fd) {
+bool fastd_poll_fd_close(fastd_poll_fd_t * const fd) {
 	if (fd->fd < 0 || (size_t)fd->fd >= VECTOR_LEN(ctx.fds))
 		exit_bug("fastd_poll_fd_close: invalid FD");
 

--- a/src/polling.h
+++ b/src/polling.h
@@ -33,9 +33,9 @@ void fastd_poll_free(void);
 #define FASTD_POLL_FD(type, fd) ((fastd_poll_fd_t){ type, fd })
 
 /** Registers a new file descriptor to poll on */
-void fastd_poll_fd_register(fastd_poll_fd_t *fd);
+void fastd_poll_fd_register(fastd_poll_fd_t * const fd);
 /** Unregisters and closes a file descriptor */
-bool fastd_poll_fd_close(fastd_poll_fd_t *fd);
+bool fastd_poll_fd_close(fastd_poll_fd_t * const fd);
 
 /** Waits for the next input event */
 void fastd_poll_handle(void);

--- a/src/pqueue.c
+++ b/src/pqueue.c
@@ -18,7 +18,7 @@
 
 
 /** Links an element at the position specified by \e pqueue */
-static inline void pqueue_link(fastd_pqueue_t **pqueue, fastd_pqueue_t *elem) {
+static inline void pqueue_link(fastd_pqueue_t ** const pqueue, fastd_pqueue_t * const elem) {
 	if (elem->next)
 		exit_bug("pqueue_link: element already linked");
 
@@ -31,7 +31,7 @@ static inline void pqueue_link(fastd_pqueue_t **pqueue, fastd_pqueue_t *elem) {
 }
 
 /** Unlinks an element */
-static inline void pqueue_unlink(fastd_pqueue_t *elem) {
+static inline void pqueue_unlink(fastd_pqueue_t * const elem) {
 	*elem->pprev = elem->next;
 	if (elem->next)
 		elem->next->pprev = elem->pprev;
@@ -45,7 +45,7 @@ static inline void pqueue_unlink(fastd_pqueue_t *elem) {
 
    \e pqueue2 may be empty (NULL)
 */
-static fastd_pqueue_t *pqueue_merge(fastd_pqueue_t *pqueue1, fastd_pqueue_t *pqueue2) {
+static fastd_pqueue_t *pqueue_merge(fastd_pqueue_t * const pqueue1, fastd_pqueue_t * const pqueue2) {
 	if (!pqueue1)
 		exit_bug("pqueue_merge: pqueue1 unset");
 	if (pqueue1->next)
@@ -73,7 +73,7 @@ static fastd_pqueue_t *pqueue_merge(fastd_pqueue_t *pqueue1, fastd_pqueue_t *pqu
 }
 
 /** Merges a list of priority queues */
-static fastd_pqueue_t *pqueue_merge_pairs(fastd_pqueue_t *pqueue0) {
+static fastd_pqueue_t *pqueue_merge_pairs(fastd_pqueue_t * const pqueue0) {
 	if (!pqueue0)
 		return NULL;
 
@@ -93,7 +93,7 @@ static fastd_pqueue_t *pqueue_merge_pairs(fastd_pqueue_t *pqueue0) {
 }
 
 /** Inserts a new element into a priority queue */
-void fastd_pqueue_insert(fastd_pqueue_t **pqueue, fastd_pqueue_t *elem) {
+void fastd_pqueue_insert(fastd_pqueue_t ** const pqueue, fastd_pqueue_t * const elem) {
 	if (elem->pprev || elem->next || elem->children)
 		exit_bug("fastd_pqueue_insert: tried to insert linked pqueue element");
 
@@ -102,7 +102,7 @@ void fastd_pqueue_insert(fastd_pqueue_t **pqueue, fastd_pqueue_t *elem) {
 }
 
 /** Removes an element from a priority queue */
-void fastd_pqueue_remove(fastd_pqueue_t *elem) {
+void fastd_pqueue_remove(fastd_pqueue_t * const elem) {
 	if (!fastd_pqueue_linked(elem)) {
 		if (elem->children || elem->next)
 			exit_bug("fastd_pqueue_remove: corrupted pqueue item");

--- a/src/pqueue.h
+++ b/src/pqueue.h
@@ -27,9 +27,9 @@ struct fastd_pqueue {
 
 
 /** Checks if an element is currently part of a priority queue */
-static inline bool fastd_pqueue_linked(fastd_pqueue_t *elem) {
+static inline bool fastd_pqueue_linked(const fastd_pqueue_t * const elem) {
 	return elem->pprev;
 }
 
-void fastd_pqueue_insert(fastd_pqueue_t **pqueue, fastd_pqueue_t *elem);
-void fastd_pqueue_remove(fastd_pqueue_t *elem);
+void fastd_pqueue_insert(fastd_pqueue_t ** const pqueue, fastd_pqueue_t * const elem);
+void fastd_pqueue_remove(fastd_pqueue_t * const elem);

--- a/src/random.c
+++ b/src/random.c
@@ -19,7 +19,7 @@
 /**
    Provides a given amount of cryptographic random data
 */
-void fastd_random_bytes(void *buffer, size_t len, bool secure) {
+void fastd_random_bytes(void * const buffer, const size_t len, const bool secure) {
 	int fd;
 	size_t read_bytes = 0;
 

--- a/src/sem.h
+++ b/src/sem.h
@@ -25,20 +25,20 @@ typedef dispatch_semaphore_t fastd_sem_t;
 
 
 /** Initializes a semaphore with a given value */
-static inline void fastd_sem_init(fastd_sem_t *sem, unsigned value) {
+static inline void fastd_sem_init(fastd_sem_t * const sem, const unsigned value) {
 	*sem = dispatch_semaphore_create(value);
 	if (!*sem)
 		exit_errno("dispatch_semaphore_create");
 }
 
 /** Increments the semaphore */
-static inline void fastd_sem_post(fastd_sem_t *sem) {
+static inline void fastd_sem_post(fastd_sem_t * const sem) {
 	if (dispatch_semaphore_signal(*sem))
 		exit_errno("sem_post");
 }
 
 /** Tries to decrement the semaphore */
-static inline bool fastd_sem_trywait(fastd_sem_t *sem) {
+static inline bool fastd_sem_trywait(fastd_sem_t * const sem) {
 	return !dispatch_semaphore_wait(*sem, DISPATCH_TIME_NOW);
 }
 
@@ -51,19 +51,19 @@ typedef sem_t fastd_sem_t;
 
 
 /** Initializes a semaphore with a given value */
-static inline void fastd_sem_init(fastd_sem_t *sem, unsigned value) {
+static inline void fastd_sem_init(fastd_sem_t * const sem, const unsigned value) {
 	if (sem_init(sem, 0, value))
 		exit_errno("sem_init");
 }
 
 /** Increments the semaphore */
-static inline void fastd_sem_post(fastd_sem_t *sem) {
+static inline void fastd_sem_post(fastd_sem_t * const sem) {
 	if (sem_post(sem))
 		exit_errno("sem_post");
 }
 
 /** Tries to decrement the semaphore */
-static inline bool fastd_sem_trywait(fastd_sem_t *sem) {
+static inline bool fastd_sem_trywait(fastd_sem_t * const sem) {
 	return !sem_trywait(sem);
 }
 

--- a/src/send.c
+++ b/src/send.c
@@ -22,7 +22,7 @@
 
 
 /** Adds packet info to ancillary control messages */
-static inline void add_pktinfo(struct msghdr *msg, const fastd_peer_address_t *local_addr) {
+static inline void add_pktinfo(struct msghdr * const msg, const fastd_peer_address_t * const local_addr) {
 #ifdef __ANDROID__
 	/* PKTINFO will mess with Android VpnService.protect(socket) */
 	if (conf.android_integration)
@@ -67,8 +67,8 @@ static inline void add_pktinfo(struct msghdr *msg, const fastd_peer_address_t *l
 
 /** Sends a packet */
 void fastd_send(
-	const fastd_socket_t *sock, const fastd_peer_address_t *local_addr, const fastd_peer_address_t *remote_addr,
-	fastd_peer_t *peer, fastd_buffer_t *buffer, size_t stat_size) {
+	const fastd_socket_t * const sock, const fastd_peer_address_t * const local_addr, const fastd_peer_address_t * const remote_addr,
+	fastd_peer_t * const peer, fastd_buffer_t * const buffer, const size_t stat_size) {
 	if (!sock)
 		exit_bug("send: sock == NULL");
 
@@ -158,7 +158,7 @@ void fastd_send(
 }
 
 /** Encrypts and sends a payload packet to all peers */
-static inline void send_all(fastd_buffer_t *buffer, fastd_peer_t *source) {
+static inline void send_all(fastd_buffer_t * const buffer, const fastd_peer_t * const source) {
 	size_t i;
 	for (i = 0; i < VECTOR_LEN(ctx.peers); i++) {
 		fastd_peer_t *dest = VECTOR_INDEX(ctx.peers, i);
@@ -178,7 +178,7 @@ static inline void send_all(fastd_buffer_t *buffer, fastd_peer_t *source) {
 }
 
 /** Handles sending of a payload packet to a single peer in TAP mode */
-static inline bool send_data_tap_single(fastd_buffer_t *buffer, fastd_peer_t *source) {
+static inline bool send_data_tap_single(fastd_buffer_t * const buffer, const fastd_peer_t * const source) {
 	if (conf.mode != MODE_TAP)
 		return false;
 
@@ -215,7 +215,7 @@ static inline bool send_data_tap_single(fastd_buffer_t *buffer, fastd_peer_t *so
 }
 
 /** Sends a buffer of payload data to other peers */
-void fastd_send_data(fastd_buffer_t *buffer, fastd_peer_t *source, fastd_peer_t *dest) {
+void fastd_send_data(fastd_buffer_t * const buffer, fastd_peer_t * const source, fastd_peer_t * const dest) {
 	if (dest) {
 		conf.protocol->send(dest, buffer);
 		return;

--- a/src/socket.c
+++ b/src/socket.c
@@ -21,7 +21,7 @@
 
    \return The new socket's file descriptor
 */
-static int bind_socket(const fastd_bind_address_t *addr) {
+static int bind_socket(const fastd_bind_address_t * const addr) {
 	int fd = -1;
 	int af = AF_UNSPEC;
 
@@ -157,7 +157,7 @@ error:
 }
 
 /** Gets the address a socket is bound to and sets it in the socket structure */
-static void set_bound_address(fastd_socket_t *sock) {
+static void set_bound_address(fastd_socket_t * const sock) {
 	fastd_peer_address_t addr = {};
 	socklen_t len = sizeof(addr);
 
@@ -198,7 +198,7 @@ void fastd_socket_bind_all(void) {
 }
 
 /** Opens a single socket bound to a random port for the given address family */
-fastd_socket_t *fastd_socket_open(fastd_peer_t *peer, int af) {
+fastd_socket_t *fastd_socket_open(fastd_peer_t * const peer, const int af) {
 	const fastd_bind_address_t any_address = { .addr.sa.sa_family = af };
 
 	const fastd_bind_address_t *bind_address;
@@ -234,7 +234,7 @@ fastd_socket_t *fastd_socket_open(fastd_peer_t *peer, int af) {
 }
 
 /** Closes a socket */
-void fastd_socket_close(fastd_socket_t *sock) {
+void fastd_socket_close(fastd_socket_t * const sock) {
 	if (sock->fd.fd >= 0) {
 		if (!fastd_poll_fd_close(&sock->fd))
 			pr_error_errno("closing socket: close");
@@ -249,7 +249,7 @@ void fastd_socket_close(fastd_socket_t *sock) {
 }
 
 /** Handles an error that occured on a socket */
-void fastd_socket_error(fastd_socket_t *sock) {
+void fastd_socket_error(fastd_socket_t * const sock) {
 	fastd_peer_address_t bound_addr = *sock->bound_addr;
 	if (!sock->addr->addr.sa.sa_family)
 		bound_addr.sa.sa_family = AF_UNSPEC;

--- a/src/task.c
+++ b/src/task.c
@@ -46,7 +46,7 @@ void fastd_task_handle(void) {
 }
 
 /** Puts a task back into the queue with a new timeout */
-void fastd_task_reschedule(fastd_task_t *task, fastd_timeout_t timeout) {
+void fastd_task_reschedule(fastd_task_t * const task, const fastd_timeout_t timeout) {
 	task->entry.value = timeout;
 	fastd_pqueue_insert(&ctx.task_queue, &task->entry);
 }

--- a/src/task.h
+++ b/src/task.h
@@ -24,17 +24,17 @@ struct fastd_task {
 
 void fastd_task_handle(void);
 
-void fastd_task_reschedule(fastd_task_t *task, fastd_timeout_t timeout);
+void fastd_task_reschedule(fastd_task_t * const task, const fastd_timeout_t timeout);
 fastd_timeout_t fastd_task_queue_timeout(void);
 
 
 /** Checks if the given task is currently scheduled */
-static inline bool fastd_task_scheduled(fastd_task_t *task) {
+static inline bool fastd_task_scheduled(fastd_task_t *const task) {
 	return fastd_pqueue_linked(&task->entry);
 }
 
 /** Gets the timeout of a task */
-static inline fastd_timeout_t fastd_task_timeout(fastd_task_t *task) {
+static inline fastd_timeout_t fastd_task_timeout(fastd_task_t * const task) {
 	if (!fastd_task_scheduled(task))
 		return FASTD_TIMEOUT_INV;
 
@@ -42,17 +42,17 @@ static inline fastd_timeout_t fastd_task_timeout(fastd_task_t *task) {
 }
 
 /** Removes a task from the queue */
-static inline void fastd_task_unschedule(fastd_task_t *task) {
+static inline void fastd_task_unschedule(fastd_task_t * const task) {
 	fastd_pqueue_remove(&task->entry);
 }
 
 /** Puts a task back into the queue with a new timeout relative to the old one */
-static inline void fastd_task_reschedule_relative(fastd_task_t *task, int64_t delay) {
+static inline void fastd_task_reschedule_relative(fastd_task_t * const task, const int64_t delay) {
 	fastd_task_reschedule(task, task->entry.value + delay);
 }
 
 /** Schedules a task with given type and timeout */
-static inline void fastd_task_schedule(fastd_task_t *task, fastd_task_type_t type, fastd_timeout_t timeout) {
+static inline void fastd_task_schedule(fastd_task_t * const task, const fastd_task_type_t type, const fastd_timeout_t timeout) {
 	task->type = type;
 	fastd_task_reschedule(task, timeout);
 }

--- a/src/time.c
+++ b/src/time.c
@@ -27,7 +27,7 @@ int64_t fastd_get_time(void) {
 	if (!timebase_info.denom)
 		mach_timebase_info(&timebase_info);
 
-	int64_t nsecs = (((long double)mach_absolute_time()) * timebase_info.numer) / timebase_info.denom;
+	const int64_t nsecs = (((long double)mach_absolute_time()) * timebase_info.numer) / timebase_info.denom;
 	return nsecs / 1000000;
 }
 

--- a/src/vector.c
+++ b/src/vector.c
@@ -28,17 +28,18 @@
 
    Internal function, use VECTOR_RESIZE() instead.
 */
-void _fastd_vector_resize(fastd_vector_desc_t *desc, void **data, size_t n, size_t elemsize) {
+void _fastd_vector_resize(fastd_vector_desc_t * const desc, void ** const data, const size_t n, const size_t elemsize) {
 	desc->length = n;
 
 	size_t alloc = desc->allocated;
+	size_t n_alloc = n;
 
 	if (!alloc) {
 		alloc = MIN_VECTOR_ALLOC;
-		n = n * 3 / 2;
+		n_alloc = n_alloc * 3 / 2;
 	}
 
-	while (alloc < n) {
+	while (alloc < n_alloc) {
 		alloc <<= 1;
 		if (!alloc) {
 			errno = EOVERFLOW;
@@ -57,7 +58,7 @@ void _fastd_vector_resize(fastd_vector_desc_t *desc, void **data, size_t n, size
 
    Internal function, use VECTOR_INSERT() and VECTOR_ADD() instead.
 */
-void _fastd_vector_insert(fastd_vector_desc_t *desc, void **data, void *element, size_t pos, size_t elemsize) {
+void _fastd_vector_insert(fastd_vector_desc_t * const desc, void ** const data, const void * const element, const size_t pos, const size_t elemsize) {
 	_fastd_vector_resize(desc, data, desc->length + 1, elemsize);
 
 	void *p = *data + pos * elemsize;
@@ -71,7 +72,7 @@ void _fastd_vector_insert(fastd_vector_desc_t *desc, void **data, void *element,
 
    Internal function, use VECTOR_DELETE() instead.
 */
-void _fastd_vector_delete(fastd_vector_desc_t *desc, void **data, size_t pos, size_t elemsize) {
+void _fastd_vector_delete(fastd_vector_desc_t * const desc, void ** const data, const size_t pos, const size_t elemsize) {
 	void *p = *data + pos * elemsize;
 	memmove(p, p + elemsize, (desc->length - pos - 1) * elemsize);
 

--- a/src/vector.h
+++ b/src/vector.h
@@ -35,9 +35,9 @@ typedef struct fastd_vector_desc {
 	}
 
 
-void _fastd_vector_resize(fastd_vector_desc_t *desc, void **data, size_t n, size_t elemsize);
-void _fastd_vector_insert(fastd_vector_desc_t *desc, void **data, void *element, size_t pos, size_t elemsize);
-void _fastd_vector_delete(fastd_vector_desc_t *desc, void **data, size_t pos, size_t elemsize);
+void _fastd_vector_resize(fastd_vector_desc_t * const desc, void ** const data, const size_t n, const size_t elemsize);
+void _fastd_vector_insert(fastd_vector_desc_t * const desc, void ** const data, const void * const element, const size_t pos, size_t elemsize);
+void _fastd_vector_delete(fastd_vector_desc_t * const desc, void ** const data, const size_t pos, const size_t elemsize);
 
 
 /**

--- a/src/verify.c
+++ b/src/verify.c
@@ -28,7 +28,7 @@
    do_verify() may be called from secondary threads as all information about the peer
    to verify is encoded in the supplied environment
 */
-static bool do_verify(const fastd_shell_env_t *env) {
+static bool do_verify(const fastd_shell_env_t * const env) {
 	int ret;
 	if (!fastd_shell_command_isset(&conf.on_verify))
 		exit_bug("tried to verify peer without on-verify command");
@@ -55,7 +55,7 @@ typedef struct verify_arg {
 } verify_arg_t;
 
 /** Verifier thread main function */
-static void *do_verify_thread(void *p) {
+static void *do_verify_thread(void * const p) {
 	verify_arg_t *arg = p;
 
 	arg->ret.ok = do_verify(arg->env);
@@ -78,8 +78,8 @@ static void *do_verify_thread(void *p) {
    notification mechanism.
 */
 fastd_tristate_t fastd_verify_peer(
-	fastd_peer_t *peer, fastd_socket_t *sock, const fastd_peer_address_t *local_addr,
-	const fastd_peer_address_t *remote_addr, const void *data, size_t data_len) {
+	fastd_peer_t * const peer, fastd_socket_t * const sock, const fastd_peer_address_t * const local_addr,
+	const fastd_peer_address_t * const remote_addr, const void *data, const size_t data_len) {
 	if (!fastd_shell_command_isset(&conf.on_verify))
 		exit_bug("tried to verify peer without on-verify command");
 

--- a/src/verify.h
+++ b/src/verify.h
@@ -18,7 +18,7 @@
 #ifdef WITH_DYNAMIC_PEERS
 
 fastd_tristate_t fastd_verify_peer(
-	fastd_peer_t *peer, fastd_socket_t *sock, const fastd_peer_address_t *local_addr,
-	const fastd_peer_address_t *remote_addr, const void *data, size_t data_len);
+	fastd_peer_t * const peer, fastd_socket_t * const sock, const fastd_peer_address_t * constlocal_addr,
+	const fastd_peer_address_t * const remote_addr, const void *data, const size_t data_len);
 
 #endif /* WITH_DYNAMIC_PEERS */


### PR DESCRIPTION
It compiles. And with only very few exceptions this only introduces "const" as a keyword. This is meant to help the the human to understand the API more easily and there  is some hope that also the compiler finds it easier to inline the code more efficiently. And I just like it - more for a C++ app than for pure C - but I like it everywhere.

Hoping to match your taste.
Steffen