### PR TITLE
doc: Fix incorrect "persist interface" examples

### DIFF
--- a/doc/source/manual/config.rst
+++ b/doc/source/manual/config.rst
@@ -202,7 +202,7 @@ Example config:
   * A Linux kernel with L2TP Ethernet Pseudowire support is required
   * L2TP offloading must be enabled in the fastd build (default on Linux)
   * ``mode`` must be set to ``multitap``
-  * ``persist iface`` must be set to ``no``
+  * ``persist interface`` must be set to ``no``
 
   Using the multi-TAP mode can be inconvenient with high numbers of peers, as it will create a separate network
   interface for each peer. As peers in TAP and multi-TAP modes can communicate with each other, using TAP mode

--- a/doc/source/releases/v19.rst
+++ b/doc/source/releases/v19.rst
@@ -32,7 +32,7 @@ Bugfixes
   environments like buildroot
 * Fix build on MacOS 10.12+
 * Fix fast reconnect when changing networks on recent Linux kernels
-* Fix segfault in *tun*/*multitap* mode with *persist iface no*
+* Fix segfault in *tun*/*multitap* mode with *persist interface no*
 * Fix segfault in resolver with musl libc 1.1.20+
 * Fix segfault when failing to create an interface on FreeBSD
 * Do not print local address as a v4-mapped IPv6 address in log messages and


### PR DESCRIPTION
The lexer doesn't understand the token ``iface`` and thus parsing a config with a line ``persist iface`` will break the config parser. The correct way of writing such a config statement is ``persist interface yes|no;``