### PR TITLE
doc .. config.rst - typo - that -> than

### DIFF
--- a/doc/source/manual/config.rst
+++ b/doc/source/manual/config.rst
@@ -365,4 +365,4 @@ Example config:
 | ``float yes|no;``
 
   The float option can be used to accept connections from the peer with the specified key from
-  other addresses that the configured ones.
+  other addresses than the configured ones.


### PR DESCRIPTION
I do not think I understood the effect of "float". Maybe you could use that opportunity to explain this a bit more or to give a pointer to an example where this becomes more obvious. Thanks! 